### PR TITLE
Add site count feature to front page

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -25,7 +25,19 @@ $sites = get_sites();
 echo festiveGreeting(time());
 echo getBrithday();
 ?>
-<h1 class="govuk-heading-l govuk-grid-column-full govuk-!-margin-top-6">Hale site dashboards</h1>
+<h1 class="govuk-heading-l govuk-grid-column-full govuk-!-margin-top-6">Platform metrics</h1>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+      <h2 class="gem-c-heading gem-c-heading--font-size-27">Sites hosted on the platform</h2>
+        <span class="govuk-heading-xl"><?php echo get_site_count(); ?></span>
+      </div>
+    </div>
+  </main>
+</div>
+
 <div class="govuk-grid-column-full">
 <?php
 foreach ( $sites as $site ) {

--- a/functions.php
+++ b/functions.php
@@ -226,3 +226,8 @@ function getBrithday() {
     ';
     }
 }
+
+/**
+ * Key computed metrics to display on the dashboard
+ */
+require get_stylesheet_directory() . '/inc/dashboard-metrics.php';

--- a/inc/dashboard-metrics.php
+++ b/inc/dashboard-metrics.php
@@ -1,0 +1,8 @@
+<?php
+
+function get_site_count()
+{
+    return count(get_sites());
+}
+
+


### PR DESCRIPTION
Add a basic site counter to the front page so you can see the site count at quick glance. As per some of the designs in the dashboard design sprint. 
https://miro.com/app/board/uXjVMgITn_A=/?moveToWidget=3458764565277267954&cot=14&share_link_id=108394086523