### PR TITLE
 Hale Dashboard refresh: Dark mode, dashboard redesign and performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ wp-config.php
 # database
 *.sql
 
+# AI
+claude/
+.claude
+
 # htaccess
 /.htaccess
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
+return (new Config())
+    ->setParallelConfig(ParallelConfigFactory::detect()) // @TODO 4.0 no need to call this manually
+    ->setRiskyAllowed(false)
+    ->setRules([
+        '@auto' => true
+    ])
+    // 💡 by default, Fixer looks for `*.php` files excluding `./vendor/` - here, you can groom this config
+    ->setFinder(
+        (new Finder())
+            // 💡 root folder to check
+            ->in(__DIR__)
+            // 💡 additional files, eg bin entry file
+            // ->append([__DIR__.'/bin-entry-file'])
+            // 💡 folders to exclude, if any
+            // ->exclude([/* ... */])
+            // 💡 path patterns to exclude, if any
+            // ->notPath([/* ... */])
+            // 💡 extra configs
+            // ->ignoreDotFiles(false) // true by default in v3, false in v4 or future mode
+            // ->ignoreVCS(true) // true by default
+    )
+;

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -10,7 +10,7 @@ return (new Config())
     ->setParallelConfig(ParallelConfigFactory::detect()) // @TODO 4.0 no need to call this manually
     ->setRiskyAllowed(false)
     ->setRules([
-        '@auto' => true
+        '@PSR12' => true,
     ])
     // 💡 by default, Fixer looks for `*.php` files excluding `./vendor/` - here, you can groom this config
     ->setFinder(

--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -19,10 +19,7 @@
 		}
 		var btn = document.querySelector('.hd-theme-toggle');
 		if (btn) {
-			var isDark = theme === 'dark';
-			btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
-			var label = btn.querySelector('.hd-theme-toggle__label');
-			if (label) label.textContent = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+			btn.setAttribute('aria-checked', theme === 'dark' ? 'true' : 'false');
 		}
 	}
 
@@ -45,6 +42,10 @@
 		applyTheme(currentTheme());
 		var btn = document.querySelector('.hd-theme-toggle');
 		if (!btn) return;
+
+		var header = document.querySelector('.govuk-header__container');
+		if (header) header.appendChild(btn);
+
 		btn.addEventListener('click', function () {
 			var next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
 			try { localStorage.setItem(STORAGE_KEY, next); } catch (e) {}

--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -1,0 +1,54 @@
+(function () {
+	var STORAGE_KEY = 'hd-theme';
+	var root = document.documentElement;
+
+	function currentTheme() {
+		var stored = null;
+		try { stored = localStorage.getItem(STORAGE_KEY); } catch (e) {}
+		if (stored === 'dark' || stored === 'light') return stored;
+		return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+			? 'dark'
+			: 'light';
+	}
+
+	function applyTheme(theme) {
+		if (theme === 'dark') {
+			root.setAttribute('data-theme', 'dark');
+		} else {
+			root.removeAttribute('data-theme');
+		}
+		var btn = document.querySelector('.hd-theme-toggle');
+		if (btn) {
+			var isDark = theme === 'dark';
+			btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+			var label = btn.querySelector('.hd-theme-toggle__label');
+			if (label) label.textContent = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+		}
+	}
+
+	applyTheme(currentTheme());
+
+	if (window.matchMedia) {
+		var mq = window.matchMedia('(prefers-color-scheme: dark)');
+		var osListener = function (e) {
+			var stored = null;
+			try { stored = localStorage.getItem(STORAGE_KEY); } catch (err) {}
+			if (stored !== 'dark' && stored !== 'light') {
+				applyTheme(e.matches ? 'dark' : 'light');
+			}
+		};
+		if (mq.addEventListener) mq.addEventListener('change', osListener);
+		else if (mq.addListener) mq.addListener(osListener);
+	}
+
+	document.addEventListener('DOMContentLoaded', function () {
+		applyTheme(currentTheme());
+		var btn = document.querySelector('.hd-theme-toggle');
+		if (!btn) return;
+		btn.addEventListener('click', function () {
+			var next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+			try { localStorage.setItem(STORAGE_KEY, next); } catch (e) {}
+			applyTheme(next);
+		});
+	});
+})();

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,25 +1,29 @@
 (function () {
 	var nameInput = document.getElementById('hd-search-name');
 	var idInput   = document.getElementById('hd-search-id');
+	var slugInput = document.getElementById('hd-search-slug');
 	var countEl   = document.getElementById('hd-search-count');
 
-	if (!nameInput || !idInput) return;
+	if (!nameInput || !idInput || !slugInput) return;
 
 	var items = Array.from(document.querySelectorAll('.hale-dash-site-item'));
 
 	function filter() {
 		var nameQuery = nameInput.value.trim().toLowerCase();
 		var idQuery   = idInput.value.trim();
+		var slugQuery = slugInput.value.trim().toLowerCase();
 		var visible   = 0;
 
 		items.forEach(function (item) {
 			var name   = item.getAttribute('data-site-name') || '';
 			var siteId = item.getAttribute('data-site-id') || '';
+			var slug   = item.getAttribute('data-site-slug') || '';
 
 			var nameMatch = !nameQuery || name.indexOf(nameQuery) !== -1;
 			var idMatch   = !idQuery   || siteId === idQuery;
+			var slugMatch = !slugQuery || slug.indexOf(slugQuery) !== -1;
 
-			if (nameMatch && idMatch) {
+			if (nameMatch && idMatch && slugMatch) {
 				item.style.display = '';
 				visible++;
 			} else {
@@ -27,7 +31,7 @@
 			}
 		});
 
-		if (nameQuery || idQuery) {
+		if (nameQuery || idQuery || slugQuery) {
 			countEl.textContent = visible + ' of ' + items.length + ' sites shown';
 		} else {
 			countEl.textContent = '';
@@ -36,4 +40,5 @@
 
 	nameInput.addEventListener('input', filter);
 	idInput.addEventListener('input', filter);
+	slugInput.addEventListener('input', filter);
 })();

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -4,7 +4,7 @@
 	var slugInput = document.getElementById('hd-search-slug');
 	var countEl   = document.getElementById('hd-search-count');
 
-	if (!nameInput || !idInput || !slugInput) return;
+	if (!nameInput || !idInput || !slugInput || !countEl) return;
 
 	var items = Array.from(document.querySelectorAll('.hale-dash-site-item'));
 

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,39 @@
+(function () {
+	var nameInput = document.getElementById('hd-search-name');
+	var idInput   = document.getElementById('hd-search-id');
+	var countEl   = document.getElementById('hd-search-count');
+
+	if (!nameInput || !idInput) return;
+
+	var items = Array.from(document.querySelectorAll('.hale-dash-site-item'));
+
+	function filter() {
+		var nameQuery = nameInput.value.trim().toLowerCase();
+		var idQuery   = idInput.value.trim();
+		var visible   = 0;
+
+		items.forEach(function (item) {
+			var name   = item.getAttribute('data-site-name') || '';
+			var siteId = item.getAttribute('data-site-id') || '';
+
+			var nameMatch = !nameQuery || name.indexOf(nameQuery) !== -1;
+			var idMatch   = !idQuery   || siteId === idQuery;
+
+			if (nameMatch && idMatch) {
+				item.style.display = '';
+				visible++;
+			} else {
+				item.style.display = 'none';
+			}
+		});
+
+		if (nameQuery || idQuery) {
+			countEl.textContent = visible + ' of ' + items.length + ' sites shown';
+		} else {
+			countEl.textContent = '';
+		}
+	}
+
+	nameInput.addEventListener('input', filter);
+	idInput.addEventListener('input', filter);
+})();

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -15,6 +15,12 @@
 	content: var(--govuk-frontend-version);
 }
 
+// Tighten main wrapper padding for the dashboard page
+.hale-page .govuk-main-wrapper {
+	padding-top: 20px;
+	padding-bottom: 40px;
+}
+
 // -------------------------------------------------------------
 // Two-column dashboard layout
 // -------------------------------------------------------------
@@ -279,23 +285,25 @@
 	display: flex;
 	flex-wrap: wrap;
 	align-items: flex-end;
+	justify-content: flex-start;
 	gap: 0.75rem 1rem;
 	margin-bottom: 1.25rem;
 
 	&__field {
-		flex: 1 1 180px;
-	}
+		flex: 0 1 180px;
+		min-width: 140px;
 
-	&__id-input {
-		max-width: 100px;
-
-		@media (max-width: 640px) {
-			max-width: 100%;
+		&--name {
+			flex-basis: 260px;
 		}
 	}
 
+	&__id-input {
+		width: 100%;
+	}
+
 	&__count {
-		flex: 1 1 100%;
+		flex: 0 0 100%;
 		margin: 0;
 	}
 
@@ -575,13 +583,13 @@ html[data-theme="dark"] {
 	// govuk-notification-banner (success variant used by greetings + birthday)
 	// -----------------------------------------------------------
 	.govuk-notification-banner {
-		background-color: #238636 !important;   // GH success emphasis
-		border: 5px solid #238636 !important;
+		background-color: #1f6feb !important;
+		border: 5px solid #1f6feb !important;
 		color: #ffffff !important;
 
 		&__header {
-			background-color: #238636 !important;
-			border-bottom: 1px solid #2ea043 !important;
+			background-color: #1f6feb !important;
+			border-bottom: 1px solid #388bfd !important;
 			padding: 2px 15px 5px;
 		}
 

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -123,15 +123,26 @@
 	// Domain: aligned under site name, past the favicon
 	&__domain {
 		grid-area: domain;
-		display: block;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
 		font-size: var(--hd-text-meta);
 		color: var(--hd-fg-muted);
 		margin: 0;
 		min-width: 0;
 		max-width: 100%;
+	}
+
+	&__domain-text {
+		min-width: 0;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+	}
+
+	&__domain-icon {
+		flex-shrink: 0;
+		opacity: 0.7;
 	}
 
 	&__explanation {

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -69,75 +69,165 @@
 
 .website {
 	display: grid;
-	// Mobile-first: single column, users sits below domain
 	grid-template-columns: 1fr;
 	grid-template-areas:
 		"heading"
 		"domain"
+		"technical"
 		"users"
 		"footer";
-	row-gap: 0.5rem;
-	border-bottom: 1px solid #b1b4b6;
-	padding: 1rem 0;
+	row-gap: 0.75rem;
+	padding: 1rem 0 0.875rem;
+	border-bottom: 1px solid var(--hd-border);
 	align-items: start;
 
-	// Tablet+: status column on the right
 	@media (min-width: 641px) {
 		grid-template-columns: minmax(0, 1fr) auto;
 		grid-template-areas:
-			"heading  users"
-			"domain   users"
-			"footer   footer";
-		column-gap: 1rem;
+			"heading   users"
+			"domain    users"
+			"technical ."
+			"footer    footer";
+		column-gap: 2rem;
+		row-gap: 0.75rem;
 	}
 
-	&__heading    { grid-area: heading; min-width: 0; }
-	&__domain     { grid-area: domain; }
-	&__users      {
-		grid-area: users;
+	// Heading: favicon + site name side by side via flexbox
+	&__heading {
+		grid-area: heading;
 		display: flex;
-		flex-direction: row;
 		align-items: center;
-		gap: 0.5rem;
-		flex-wrap: wrap;
-
-		br { display: none; }
-
-		@media (min-width: 641px) {
-			flex-direction: column;
-			align-items: flex-end;
-			gap: 0.4rem;
-			align-self: center;
-			text-align: right;
-		}
-	}
-	&__footer     {
-		grid-area: footer;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		gap: 0.5rem;
-		flex-wrap: wrap;
+		gap: 0.4rem;
+		min-width: 0;
+		margin: 0;
 	}
 
-	&__links {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.35rem 0.5rem;
+	&__heading__text {
+		margin: 0 !important;
+		line-height: 1.3;
+		min-width: 0;
 	}
 
+	&__favicon {
+		width: 16px;
+		height: 16px;
+		border-radius: 3px;
+		flex-shrink: 0;
+	}
+
+	// Domain: aligned under site name, past the favicon
 	&__domain {
+		grid-area: domain;
 		display: block;
+		font-size: var(--hd-text-meta);
+		color: var(--hd-fg-muted);
+		margin: 0;
 		min-width: 0;
 		max-width: 100%;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		margin: 0;
+	}
 
-		@media (min-width: 641px) {
-			margin-left: 22px;
+	&__explanation {
+		font-size: var(--hd-text-meta);
+		color: var(--hd-fg-muted);
+		margin: 0;
+	}
+
+	// Meta column: status tag + online badge — stacked right
+	&__users {
+		grid-area: users;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		justify-content: center;
+		align-self: stretch;
+		gap: 0.5rem;
+		text-align: right;
+
+		br { display: none; }
+	}
+
+	&__up-down {
+		display: block;
+
+		.govuk-tag {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			min-width: 90px;
+			padding: 4px 10px;
+			border-radius: 0;
+			font-size: 1rem;
+			line-height: 1.4;
 		}
+	}
+
+	&__user-count {
+		font-size: 1rem;
+	}
+
+	&__online-count {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 90px;
+		padding: 4px 10px;
+		font-size: 1rem;
+		font-weight: 600;
+		color: #ffffff;
+		background-color: #00703c;
+		border-radius: 0;
+		line-height: 1.4;
+	}
+
+	&__technical {
+		grid-area: technical;
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.3rem 0.75rem;
+		font-size: 1rem;
+		color: var(--hd-fg-muted);
+		margin: 0;
+	}
+
+	// Env links row — aligned with slug/id text
+	&__footer {
+		grid-area: footer;
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+		margin: 0;
+	}
+
+	&__slug-title,
+	&__id-title,
+	&__users-title {
+		color: var(--hd-fg-muted);
+
+		&:after { content: ":"; }
+	}
+
+	&__slug {
+		color: var(--hd-slug-fg);
+		background-color: var(--hd-bg-subtle);
+		padding: 1px 5px;
+		border-radius: 3px;
+		font-size: 1rem;
+		white-space: nowrap;
+	}
+
+	&__id {
+		font-size: 1rem;
+	}
+
+	&__links {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.3rem;
 	}
 
 	&__environment {
@@ -146,17 +236,17 @@
 		justify-content: center;
 		min-width: 72px;
 		padding: 4px 12px;
-		font-size: var(--hd-text-meta);
+		font-size: 1rem;
 		font-weight: 600;
 		line-height: 1.4;
 		text-decoration: none;
 		color: #0b0c0c;
-		background-color: #f3f2f1;
-		border: 1px solid #b1b4b6;
+		background-color: var(--hd-bg-subtle);
+		border: 0;
 		border-radius: 4px;
 
 		&:hover {
-			background-color: #dcdcdc;
+			background-color: var(--hd-border);
 			text-decoration: none;
 		}
 
@@ -166,93 +256,12 @@
 		}
 
 		&--disabled {
-			opacity: 0.5;
+			opacity: 0.4;
 			cursor: not-allowed;
 			pointer-events: none;
 		}
 	}
 
-	&__up-down {
-		display: inline-block;
-	}
-
-	&__online-count {
-		display: inline-block;
-		margin-top: 0.4rem;
-		padding: 2px 8px;
-		font-size: var(--hd-text-meta);
-		font-weight: 600;
-		color: #ffffff;
-		background-color: #00703c;
-		border-radius: 3px;
-		line-height: 1.4;
-	}
-
-	&__favicon {
-		border-radius: 3px;
-		width: 16px;
-		height: 16px;
-		margin-right: 6px;
-		vertical-align: middle;
-	}
-
-	&__heading {
-		margin: 0;
-
-		.website__heading__text {
-			display: inline;
-			margin: 0 !important;
-			line-height: 1.3;
-		}
-
-		@media (min-width: 641px) {
-			margin-left: 22px;
-			text-indent: -22px;
-			align-self: center;
-		}
-	}
-	&__explanation {
-		margin-top: 0.25rem;
-
-		@media (min-width: 641px) {
-			margin-left: 22px;
-		}
-	}
-
-	&__technical {
-		font-size: var(--hd-text-meta);
-		color: #505a5f;
-		margin: 0;
-
-		br { display: none; }
-
-		.website__id-title {
-			margin-left: 0.75rem;
-		}
-	}
-	&__id-title,
-	&__slug-title {
-		color: inherit;
-		font-size: inherit;
-		font-weight: inherit;
-		margin: 0;
-		display: inline;
-
-		&:after {
-			content: ":";
-		}
-	}
-	&__slug {
-		color: #d13118;
-		background-color: #f3f2f1;
-		padding: 0 0.2rem;
-		font-size: var(--hd-text-meta);
-		white-space: nowrap;
-	}
-	&__id {
-		padding: 0 0.2rem;
-		font-size: var(--hd-text-meta);
-	}
 	&__warning {
 		padding: 0.75rem 1rem;
 		margin: -0.5rem 0 1rem;
@@ -264,10 +273,7 @@
 
 		p {
 			margin: 0 0 0.25rem;
-
-			&:last-child {
-				margin-bottom: 0;
-			}
+			&:last-child { margin-bottom: 0; }
 		}
 	}
 }

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 .govuk-main-wrapper .govuk-grid-column-full {
 	padding: 0 15px;
+	box-sizing: border-box;
 }
 
 @media (min-width: 769px) {
@@ -14,114 +15,237 @@
 	content: var(--govuk-frontend-version);
 }
 
+// -------------------------------------------------------------
+// Two-column dashboard layout
+// -------------------------------------------------------------
+.hale-dash-metrics-col {
+	@media (min-width: 769px) {
+		position: sticky;
+		top: 1rem;
+		align-self: flex-start;
+	}
+}
+
+.hale-dash-metrics {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 0.75rem;
+	margin-bottom: 2rem;
+
+	@media (min-width: 480px) {
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1rem;
+	}
+}
+
+.hale-dash-metric {
+	padding: 0.75rem 1rem;
+	border: 1px solid #b1b4b6;
+	border-radius: 4px;
+	background-color: #f3f2f1;
+
+	&--wide {
+		grid-column: 1 / -1;
+		background-color: transparent;
+		border: 0;
+		padding: 0.5rem 0;
+	}
+
+	h2 {
+		margin-top: 0;
+	}
+}
+
 .website {
-	display: flex;
-    justify-content: space-between;
+	display: grid;
+	// Mobile-first: single column, users sits below domain
+	grid-template-columns: 1fr;
+	grid-template-areas:
+		"heading"
+		"domain"
+		"users"
+		"footer";
+	row-gap: 0.5rem;
 	border-bottom: 1px solid #b1b4b6;
-	padding-bottom: 1rem;
-	margin-bottom: 1rem;
+	padding: 1rem 0;
 	align-items: start;
 
-	@media (min-width: 769px) {
+	// Tablet+: status column on the right
+	@media (min-width: 641px) {
+		grid-template-columns: minmax(0, 1fr) auto;
+		grid-template-areas:
+			"heading  users"
+			"domain   users"
+			"footer   footer";
+		column-gap: 1rem;
+	}
+
+	&__heading    { grid-area: heading; min-width: 0; }
+	&__domain     { grid-area: domain; }
+	&__users      {
+		grid-area: users;
+		display: flex;
+		flex-direction: row;
 		align-items: center;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+
+		br { display: none; }
+
+		@media (min-width: 641px) {
+			flex-direction: column;
+			align-items: flex-end;
+			gap: 0.4rem;
+			align-self: center;
+			text-align: right;
+		}
+	}
+	&__footer     {
+		grid-area: footer;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 0.5rem;
+		flex-wrap: wrap;
 	}
 
 	&__links {
 		display: flex;
-		justify-content: space-between;
-		min-width: fit-content;
-		flex-direction: column;
+		flex-wrap: wrap;
+		gap: 0.35rem 0.5rem;
+	}
 
-		@media (min-width: 769px) {
-			flex-direction: row;
+	&__domain {
+		display: block;
+		min-width: 0;
+		max-width: 100%;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		margin: 0;
+
+		@media (min-width: 641px) {
+			margin-left: 22px;
 		}
 	}
 
 	&__environment {
-		min-width: fit-content;
-		margin-left: 0.2rem;
-		margin-right: 0.5rem;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 72px;
+		padding: 4px 12px;
+		font-size: var(--hd-text-meta);
+		font-weight: 600;
+		line-height: 1.4;
+		text-decoration: none;
+		color: #0b0c0c;
+		background-color: #f3f2f1;
+		border: 1px solid #b1b4b6;
+		border-radius: 4px;
+
+		&:hover {
+			background-color: #dcdcdc;
+			text-decoration: none;
+		}
+
+		&:focus {
+			outline: 3px solid #ffdd00;
+			outline-offset: 0;
+		}
+
+		&--disabled {
+			opacity: 0.5;
+			cursor: not-allowed;
+			pointer-events: none;
+		}
 	}
 
 	&__up-down {
-		width:120px;
-		text-align: center;
-	}
-
-	&__users {
-		width:100px;
-		text-align: center;
-		margin-right:0.3rem;
-		line-height: 1.55;
+		display: inline-block;
 	}
 
 	&__favicon {
 		border-radius: 3px;
 		width: 16px;
+		height: 16px;
 		margin-right: 6px;
+		vertical-align: middle;
 	}
 
 	&__heading {
-		width: 50%;
+		margin: 0;
 
 		.website__heading__text {
-			display: block;
+			display: inline;
+			margin: 0 !important;
+			line-height: 1.3;
 		}
 
 		@media (min-width: 641px) {
 			margin-left: 22px;
 			text-indent: -22px;
-			.website__heading__text {
-				display: inline;
-			}
+			align-self: center;
 		}
 	}
 	&__explanation {
+		margin-top: 0.25rem;
+
 		@media (min-width: 641px) {
 			margin-left: 22px;
 		}
 	}
 
 	&__technical {
-		width: 180px;
-		font-size: 16px;
+		font-size: var(--hd-text-meta);
 		color: #505a5f;
+		margin: 0;
+
+		br { display: none; }
+
+		.website__id-title {
+			margin-left: 0.75rem;
+		}
 	}
 	&__id-title,
 	&__slug-title {
 		color: inherit;
 		font-size: inherit;
+		font-weight: inherit;
 		margin: 0;
+		display: inline;
 
-		@media (min-width: 641px) {
-			font-weight: inherit;
-			display: inline;
-			&:after {
-				content: ":";
-			}
+		&:after {
+			content: ":";
 		}
-	}
-	&__id-title{
-		margin-top:1rem;
 	}
 	&__slug {
 		color: #d13118;
 		background-color: #f3f2f1;
 		padding: 0 0.2rem;
-		font-size: 14px;
+		font-size: var(--hd-text-meta);
 		white-space: nowrap;
 	}
 	&__id {
 		padding: 0 0.2rem;
-		font-size: 18px;
+		font-size: var(--hd-text-meta);
 	}
 	&__warning {
-		background: #fff;
-		padding: 0 22px 22px;
-		font-size: 19px;
-		margin: -30px 0 22px;
-		line-height: 1.6;
-		border-bottom: 1px solid #b1b4b6;
+		padding: 0.75rem 1rem;
+		margin: -0.5rem 0 1rem;
+		font-size: var(--hd-text-body);
+		line-height: 1.5;
+		background: #fff7d6;
+		border-left: 4px solid #d29922;
+		border-radius: 0 4px 4px 0;
+
+		p {
+			margin: 0 0 0.25rem;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
 	}
 }
 
@@ -146,4 +270,386 @@
 		background-color: #d4351c;
 		color:white;
 	}
+}
+
+// -------------------------------------------------------------
+// Site search
+// -------------------------------------------------------------
+.hale-dash-search {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-end;
+	gap: 0.75rem 1rem;
+	margin-bottom: 1.25rem;
+
+	&__field {
+		flex: 1 1 180px;
+	}
+
+	&__id-input {
+		max-width: 100px;
+
+		@media (max-width: 640px) {
+			max-width: 100%;
+		}
+	}
+
+	&__count {
+		flex: 1 1 100%;
+		margin: 0;
+	}
+
+	.govuk-label {
+		margin-bottom: 4px;
+	}
+}
+
+// -------------------------------------------------------------
+// Dark mode — GitHub dark palette
+// Activated by `data-theme="dark"` on <html>.
+// JS resolves: localStorage > prefers-color-scheme.
+// -------------------------------------------------------------
+:root {
+	--hd-bg: #ffffff;
+	--hd-bg-subtle: #f3f2f1;
+	--hd-fg: #0b0c0c;
+	--hd-fg-muted: #505a5f;
+	--hd-border: #b1b4b6;
+	--hd-link: #1d70b8;
+	--hd-link-visited: #4c2c92;
+	--hd-link-hover: #003078;
+	--hd-slug-fg: #d13118;
+	--hd-warning-bg: #ffffff;
+
+	// Type scale — govuk-body-s = 1rem (16px), metadata = 0.875rem (14px)
+	--hd-text-body: 1rem;
+	--hd-text-meta: 0.875rem;
+}
+
+html[data-theme="dark"] {
+	--hd-bg: #0d1117;
+	--hd-bg-subtle: #161b22;
+	--hd-fg: #c9d1d9;
+	--hd-fg-muted: #8b949e;
+	--hd-border: #30363d;
+	--hd-link: #58a6ff;
+	--hd-link-visited: #a371f7;
+	--hd-link-hover: #79c0ff;
+	--hd-slug-fg: #ff7b72;
+	--hd-warning-bg: #161b22;
+
+	color-scheme: dark;
+
+	background-color: var(--hd-bg);
+	color: var(--hd-fg);
+
+	body {
+		background-color: var(--hd-bg);
+		color: var(--hd-fg);
+	}
+
+	.govuk-template__body,
+	.govuk-main-wrapper,
+	.govuk-width-container,
+	.hale-page,
+	.govuk-phase-banner {
+		background-color: var(--hd-bg);
+		color: var(--hd-fg);
+	}
+
+	// -----------------------------------------------------------
+	// Header — keep the govuk black bar; brighten text + crown
+	// -----------------------------------------------------------
+	.govuk-header,
+	.hale-header {
+		background-color: #0b0c0c !important;
+		border-bottom-color: #1f6feb !important;
+		color: #ffffff;
+
+		.govuk-header__link,
+		.govuk-header__link:link,
+		.govuk-header__link:visited,
+		.govuk-header__logotype-text {
+			color: #ffffff !important;
+		}
+
+		.govuk-header__logotype-crown,
+		.moj-header__logotype-crest {
+			fill: #ffffff;
+			color: #ffffff;
+		}
+
+		a {
+			color: #ffffff !important;
+		}
+	}
+
+	// -----------------------------------------------------------
+	// Footer — dark surface + light text
+	// -----------------------------------------------------------
+	.govuk-footer {
+		background-color: var(--hd-bg-subtle) !important;
+		border-top-color: var(--hd-border) !important;
+		color: var(--hd-fg) !important;
+
+		.govuk-footer__link,
+		a {
+			color: var(--hd-link) !important;
+
+			&:visited { color: var(--hd-link-visited) !important; }
+			&:hover   { color: var(--hd-link-hover) !important; }
+		}
+
+		.govuk-footer__licence-description,
+		.govuk-footer__copyright-logo,
+		.govuk-footer__meta-item,
+		.govuk-footer__licence-logo {
+			color: var(--hd-fg-muted) !important;
+			fill: var(--hd-fg-muted);
+		}
+	}
+
+	// Breadcrumbs + info banner (if rendered by parent)
+	.govuk-breadcrumbs,
+	.hale-information-banner,
+	.hale-secondary-top-nav {
+		background-color: var(--hd-bg) !important;
+		color: var(--hd-fg) !important;
+	}
+
+	&,
+	body,
+	.govuk-template__body,
+	.govuk-heading-xl,
+	.govuk-heading-l,
+	.govuk-heading-m,
+	.govuk-heading-s,
+	.govuk-caption-xl,
+	.govuk-caption-l,
+	.govuk-caption-m,
+	.govuk-body,
+	.govuk-body-s,
+	.govuk-body-m,
+	.govuk-body-l,
+	.govuk-list,
+	.govuk-label,
+	.govuk-fieldset__legend,
+	.govuk-table,
+	.govuk-table__header,
+	.govuk-table__cell,
+	.govuk-header__link,
+	.govuk-footer__link,
+	.govuk-phase-banner__text,
+	p, h1, h2, h3, h4, h5, h6, li, span, strong, em, dt, dd, blockquote, figcaption {
+		color: var(--hd-fg) !important;
+	}
+
+	.govuk-hint,
+	.govuk-caption-xl,
+	.govuk-caption-l,
+	.govuk-caption-m,
+	.govuk-footer__meta-item,
+	.govuk-footer__licence-description,
+	.govuk-footer__copyright-logo {
+		color: var(--hd-fg-muted) !important;
+	}
+
+	code, pre {
+		color: var(--hd-fg);
+		background-color: var(--hd-bg-subtle);
+	}
+
+	.govuk-link,
+	a {
+		color: var(--hd-link) !important;
+
+		&:visited {
+			color: var(--hd-link-visited) !important;
+		}
+		&:hover {
+			color: var(--hd-link-hover) !important;
+		}
+		&:focus {
+			color: #0b0c0c !important;
+		}
+	}
+
+	.website {
+		border-bottom-color: var(--hd-border);
+
+		&__technical {
+			color: var(--hd-fg-muted);
+		}
+
+		&__slug {
+			color: var(--hd-slug-fg);
+			background-color: var(--hd-bg-subtle);
+		}
+
+		&__warning {
+			background: var(--hd-warning-bg);
+			border-left-color: #d29922;
+			color: var(--hd-fg);
+
+			strong, p, span {
+				color: var(--hd-fg) !important;
+			}
+		}
+	}
+
+	.govuk-tag {
+		&.govuk-tag--grey {
+			background-color: #30363d;
+			color: #c9d1d9;
+		}
+		&.govuk-tag--green,
+		&.govuk-tag--turquoise {
+			background-color: #1f6f3f;
+			color: #aff5b4;
+		}
+		&.govuk-tag--blue,
+		&.hale-dash-better-tag--blue {
+			background-color: #1f6feb;
+			color: #ffffff;
+		}
+		&.govuk-tag--orange,
+		&.govuk-tag--yellow {
+			background-color: #5a4315;
+			color: #f2cc60;
+		}
+		&.govuk-tag--red,
+		&.hale-dash-better-tag--red {
+			background-color: #8e1519;
+			color: #ffdcd7;
+		}
+	}
+
+	.hale-dash-search {
+		.govuk-input {
+			background-color: var(--hd-bg-subtle) !important;
+			color: var(--hd-fg) !important;
+			border-color: var(--hd-border) !important;
+
+			&::placeholder { color: var(--hd-fg-muted) !important; }
+			&:focus { border-color: var(--hd-link) !important; }
+		}
+	}
+
+	.hale-dash-metric {
+		background-color: var(--hd-bg-subtle);
+		border-color: var(--hd-border);
+
+		&--wide {
+			background-color: transparent;
+			border: 0;
+		}
+	}
+
+	.website__environment {
+		background-color: var(--hd-bg-subtle) !important;
+		border-color: var(--hd-border) !important;
+		color: var(--hd-fg) !important;
+
+		&:hover {
+			background-color: #30363d !important;
+		}
+	}
+
+	// Favicons: svg fallback uses hard-coded dark fill — force light.
+	// img favicons keep their own colours but get a neutral panel so
+	// transparent/dark logos stay legible against dark canvas.
+	svg.website__favicon {
+		fill: var(--hd-fg);
+		path {
+			fill: currentColor !important;
+		}
+	}
+
+	img.website__favicon {
+		background-color: #ffffff;
+		padding: 1px;
+		box-sizing: content-box;
+	}
+
+	// -----------------------------------------------------------
+	// govuk-notification-banner (success variant used by greetings + birthday)
+	// -----------------------------------------------------------
+	.govuk-notification-banner {
+		background-color: #238636 !important;   // GH success emphasis
+		border: 5px solid #238636 !important;
+		color: #ffffff !important;
+
+		&__header {
+			background-color: #238636 !important;
+			border-bottom: 1px solid #2ea043 !important;
+			padding: 2px 15px 5px;
+		}
+
+		&__title {
+			color: #ffffff !important;
+		}
+
+		&__content {
+			background-color: var(--hd-bg-subtle) !important;
+			color: var(--hd-fg) !important;
+			padding: 15px;
+
+			.govuk-notification-banner__heading,
+			h3,
+			p,
+			a,
+			sup,
+			strong {
+				color: var(--hd-fg) !important;
+			}
+
+			.govuk-link,
+			a {
+				color: var(--hd-link) !important;
+
+				&:visited { color: var(--hd-link-visited) !important; }
+				&:hover   { color: var(--hd-link-hover) !important; }
+			}
+		}
+	}
+}
+
+// -------------------------------------------------------------
+// Dark mode toggle button
+// -------------------------------------------------------------
+.hd-theme-toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin: 1.5rem 0;
+	padding: 0.5rem 1rem;
+	font-family: inherit;
+	font-size: var(--hd-text-body);
+	line-height: 1.25;
+	cursor: pointer;
+	background-color: var(--hd-bg-subtle);
+	color: var(--hd-fg);
+	border: 1px solid var(--hd-border);
+	border-radius: 4px;
+
+	&:hover {
+		background-color: var(--hd-border);
+	}
+
+	&:focus {
+		outline: 3px solid #ffdd00;
+		outline-offset: 0;
+	}
+
+	&__icon {
+		width: 16px;
+		height: 16px;
+	}
+}
+
+.hd-theme-toggle-wrap {
+	display: flex;
+	justify-content: flex-end;
+	padding: 0 15px 1rem;
+	flex-wrap: wrap;
 }

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -176,6 +176,18 @@
 		display: inline-block;
 	}
 
+	&__online-count {
+		display: inline-block;
+		margin-top: 0.4rem;
+		padding: 2px 8px;
+		font-size: var(--hd-text-meta);
+		font-weight: 600;
+		color: #ffffff;
+		background-color: #00703c;
+		border-radius: 3px;
+		line-height: 1.4;
+	}
+
 	&__favicon {
 		border-radius: 3px;
 		width: 16px;
@@ -517,6 +529,10 @@ html[data-theme="dark"] {
 		}
 		&.govuk-tag--green,
 		&.govuk-tag--turquoise {
+			background-color: #1f6f3f;
+			color: #aff5b4;
+		}
+		.website__online-count {
 			background-color: #1f6f3f;
 			color: #aff5b4;
 		}

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -712,6 +712,53 @@ html[data-theme="dark"] {
 			}
 		}
 	}
+
+	// -----------------------------------------------------------
+	// Restore WP admin bar to its own default colours (dark mode
+	// overrides above were bleeding through).
+	// -----------------------------------------------------------
+	#wpadminbar {
+		background: #1d2327 !important;
+		color: #c3c4c7 !important;
+
+		*,
+		.ab-item,
+		.ab-empty-item,
+		li,
+		span,
+		strong {
+			color: #c3c4c7 !important;
+			background-color: transparent !important;
+		}
+
+		a,
+		a:visited,
+		.ab-item,
+		.ab-item:visited {
+			color: #c3c4c7 !important;
+		}
+
+		a:hover,
+		a:focus,
+		.ab-item:hover,
+		.ab-item:focus,
+		li:hover > .ab-item,
+		li.hover > .ab-item {
+			color: #72aee6 !important;
+			background-color: #2c3338 !important;
+		}
+
+		.ab-icon,
+		.ab-icon:before,
+		.ab-item:before {
+			color: #c3c4c7 !important;
+		}
+
+		.ab-sub-wrapper,
+		.ab-submenu {
+			background: #2c3338 !important;
+		}
+	}
 }
 
 // -------------------------------------------------------------

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -62,7 +62,7 @@
 		padding: 0.5rem 0;
 	}
 
-	h2 {
+	h3 {
 		margin-top: 0;
 	}
 }
@@ -293,6 +293,30 @@
 		background-color: #d4351c;
 		color:white;
 	}
+}
+
+// -------------------------------------------------------------
+// Compact header — reduce vertical height to just above site title
+// -------------------------------------------------------------
+.hale-page .govuk-header__container {
+	padding-top: 6px;
+	padding-bottom: 4px;
+}
+
+.hale-page .hale-header .govuk-header__logotype {
+	min-height: unset;
+}
+
+.hale-page h2 {
+	font-size: 2rem;
+}
+
+.hale-page h3 {
+	font-size: 1.4rem;
+}
+
+.hale-dash-metric h3 {
+	font-size: 0.875rem;
 }
 
 // -------------------------------------------------------------

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -4,6 +4,11 @@
 	box-sizing: border-box;
 }
 
+#content.govuk-width-container {
+	padding-top: 0 !important;
+	margin-top: 0 !important;
+}
+
 @media (min-width: 769px) {
 	.hale-page .govuk-width-container {
 		max-width: 1400px;
@@ -304,13 +309,39 @@
 // -------------------------------------------------------------
 // Compact header — reduce vertical height to just above site title
 // -------------------------------------------------------------
-.hale-page .govuk-header__container {
-	padding-top: 6px;
-	padding-bottom: 4px;
+// Target: 50px total header height
+.hale-page .govuk-header {
+	margin-bottom: 0 !important;
+	border-bottom-width: 4px !important;
 }
 
-.hale-page .hale-header .govuk-header__logotype {
-	min-height: unset;
+// Fixed 46px container (+ 4px border = 50px). Flex centres logo vertically.
+.hale-page .govuk-header__container {
+	display: flex !important;
+	align-items: center !important;
+	height: 46px !important;
+	padding-top: 0 !important;
+	padding-bottom: 0 !important;
+}
+
+// Strip all padding/margin from every govuk/hale element inside the header
+.hale-page .govuk-header__logo,
+.hale-page .govuk-header__logotype,
+.hale-page .govuk-header__link--homepage,
+.hale-page .hale-header__logo {
+	padding: 0 !important;
+	margin: 0 !important;
+	min-height: unset !important;
+	display: flex !important;
+	align-items: center !important;
+}
+
+.hale-page .govuk-header__logotype-text,
+.hale-page .hale-header__logotype-text--custom {
+	font-size: 1rem !important;
+	line-height: 1 !important;
+	margin: 0 !important;
+	padding: 0 !important;
 }
 
 .hale-page h2 {
@@ -370,7 +401,7 @@
 	--hd-fg: #0b0c0c;
 	--hd-fg-muted: #505a5f;
 	--hd-border: #b1b4b6;
-	--hd-link: #1d70b8;
+	--hd-link: #003078;
 	--hd-link-visited: #4c2c92;
 	--hd-link-hover: #003078;
 	--hd-slug-fg: #d13118;
@@ -417,8 +448,8 @@ html[data-theme="dark"] {
 	// -----------------------------------------------------------
 	.govuk-header,
 	.hale-header {
-		background-color: #0b0c0c !important;
-		border-bottom-color: #1f6feb !important;
+		background-color: var(--hd-bg) !important;
+		border-bottom-color: var(--hd-bg) !important;
 		color: #ffffff;
 
 		.govuk-header__link,
@@ -606,11 +637,10 @@ html[data-theme="dark"] {
 
 	.website__environment {
 		background-color: var(--hd-bg-subtle) !important;
-		border-color: var(--hd-border) !important;
 		color: var(--hd-fg) !important;
 
 		&:hover {
-			background-color: #30363d !important;
+			background-color: var(--hd-border) !important;
 		}
 	}
 

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -17,8 +17,13 @@
 
 // Tighten main wrapper padding for the dashboard page
 .hale-page .govuk-main-wrapper {
-	padding-top: 20px;
+	padding-top: 10px !important;
 	padding-bottom: 40px;
+}
+
+// Reduce the 40px bottom margin govuk applies to notification banners
+.hale-page .govuk-notification-banner {
+	margin-bottom: 25px !important;
 }
 
 // -------------------------------------------------------------
@@ -27,7 +32,7 @@
 .hale-dash-metrics-col {
 	@media (min-width: 769px) {
 		position: sticky;
-		top: 1rem;
+		top: calc(32px + 1rem);
 		align-self: flex-start;
 	}
 }

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -762,41 +762,64 @@ html[data-theme="dark"] {
 }
 
 // -------------------------------------------------------------
-// Dark mode toggle button
+// Dark mode toggle — switch-style, docked right of header
 // -------------------------------------------------------------
 .hd-theme-toggle {
 	display: inline-flex;
 	align-items: center;
-	gap: 0.5rem;
-	margin: 1.5rem 0;
-	padding: 0.5rem 1rem;
-	font-family: inherit;
-	font-size: var(--hd-text-body);
-	line-height: 1.25;
-	cursor: pointer;
-	background-color: var(--hd-bg-subtle);
-	color: var(--hd-fg);
-	border: 1px solid var(--hd-border);
+	gap: 6px;
+	margin-left: auto;
+	padding: 4px 6px;
+	background: transparent;
+	border: 0;
 	border-radius: 4px;
+	cursor: pointer;
+	color: #ffffff;
+	font-family: inherit;
+	line-height: 1;
 
-	&:hover {
-		background-color: var(--hd-border);
-	}
-
-	&:focus {
-		outline: 3px solid #ffdd00;
-		outline-offset: 0;
+	&:focus-visible {
+		outline: 2px solid #ffdd00;
+		outline-offset: 2px;
 	}
 
 	&__icon {
-		width: 16px;
-		height: 16px;
+		width: 14px;
+		height: 14px;
+		flex-shrink: 0;
+		opacity: 0.55;
+		transition: opacity 0.15s;
 	}
-}
 
-.hd-theme-toggle-wrap {
-	display: flex;
-	justify-content: flex-end;
-	padding: 0 15px 1rem;
-	flex-wrap: wrap;
+	&__track {
+		position: relative;
+		width: 32px;
+		height: 16px;
+		background: rgba(255, 255, 255, 0.25);
+		border-radius: 999px;
+		transition: background 0.2s;
+		flex-shrink: 0;
+	}
+
+	&__thumb {
+		position: absolute;
+		top: 2px;
+		left: 2px;
+		width: 12px;
+		height: 12px;
+		background: #ffffff;
+		border-radius: 50%;
+		transition: transform 0.2s;
+	}
+
+	// Light mode (default): sun lit, moon dim, thumb left
+	&__icon--sun { opacity: 1; }
+
+	// Dark mode: slide thumb right, swap icon emphasis
+	&[aria-checked="true"] {
+		.hd-theme-toggle__track { background: #1f6feb; }
+		.hd-theme-toggle__thumb { transform: translateX(16px); }
+		.hd-theme-toggle__icon--sun  { opacity: 0.55; }
+		.hd-theme-toggle__icon--moon { opacity: 1; }
+	}
 }

--- a/components/feature-metrics.php
+++ b/components/feature-metrics.php
@@ -8,11 +8,35 @@
     $this_url = get_bloginfo('url');
     $this_env = ucfirst(getenv('WP_ENVIRONMENT_TYPE'));
 
-    // How many live sites
+    // How many live sites — use get_blog_option to avoid switch_to_blog per site
     $live_site_count = 0;
     foreach ($sites as $site) {
-        if (!is_plugin_active_on_site('wp-force-login/wp-force-login.php', $site->blog_id)) $live_site_count++;
+        $active_plugins = (array) get_blog_option($site->blog_id, 'active_plugins');
+        if (!in_array('wp-force-login/wp-force-login.php', $active_plugins)) $live_site_count++;
     }
+
+    // Total users across the network
+    global $wpdb;
+    $total_network_users = (int) $wpdb->get_var("SELECT COUNT(ID) FROM {$wpdb->users}");
+
+    // Users with at least one active (non-expired) session; collect IDs for per-site lookup
+    $session_rows = $wpdb->get_results(
+        "SELECT user_id, meta_value FROM {$wpdb->usermeta} WHERE meta_key = 'session_tokens'"
+    );
+    $now = time();
+    $active_user_ids = [];
+    foreach ($session_rows as $row) {
+        $tokens = maybe_unserialize($row->meta_value);
+        if (is_array($tokens)) {
+            foreach ($tokens as $token) {
+                if (isset($token['expiration']) && $token['expiration'] > $now) {
+                    $active_user_ids[] = (int) $row->user_id;
+                    break;
+                }
+            }
+        }
+    }
+    $active_sessions = count($active_user_ids);
 ?>
 <div class="hale-dash-metrics">
     <div class="hale-dash-metric">
@@ -39,6 +63,14 @@
         <h2 class="govuk-heading-s govuk-!-margin-bottom-1">PHP</h2>
         <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo phpversion(); ?></span>
     </div>
+    <div class="hale-dash-metric">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Network users</h2>
+        <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo number_format($total_network_users); ?></span>
+    </div>
+    <div class="hale-dash-metric">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Logged in now</h2>
+        <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo $active_sessions; ?></span>
+    </div>
 
     <div class="hale-dash-metric hale-dash-metric--wide">
         <h2 class="govuk-heading-s">Site monitoring and performance</h2>
@@ -48,6 +80,9 @@
             </li>
             <li>
                 <a href="https://grafana.live.cloud-platform.service.justice.gov.uk/d/85a562078cdf77779eaa1add43ccec1e/kubernetes-compute-resources-namespace-pods?orgId=1&refresh=10s&var-datasource=default&var-cluster=&var-namespace=hale-platform-prod">Grafana dashboard (prod)</a>
+            </li>
+            <li>
+                <a href="https://grafana.live.cloud-platform.service.justice.gov.uk/d/k8s-nginx-ingress-prometheus-ng2/b89fb7c?orgId=1&refresh=1m&var-controller_class=$__all&var-pod=$__all&var-datasource=default&from=now-3h&to=now&var-namespace=$__all&var-ingress=hale-platform-ingress&timezone=browser">Grafana Nginx Ingress</a>
             </li>
             <li>
                 <a href="https://logs.cloud-platform.service.justice.gov.uk/_dashboards/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(_source),filters:!(),index:b95d8900-dd15-11ed-87c8-170407f57c9c,interval:auto,query:(language:kuery,query:''),sort:!())">Ingress logs</a>

--- a/components/feature-metrics.php
+++ b/components/feature-metrics.php
@@ -14,67 +14,47 @@
         if (!is_plugin_active_on_site('wp-force-login/wp-force-login.php', $site->blog_id)) $live_site_count++;
     }
 ?>
-<div class="govuk-width-container">
-    <div class="govuk-grid-row govuk-!-margin-bottom-9">
-        <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
-            <h2 class="govuk-heading-m">Current Environment</h2>
-            <span class="govuk-heading-xl">
-                <?php
-                    echo $this_env;
-                ?>
-            </span>
-        </div>
-        <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
-            <h2 class="govuk-heading-m">Sites hosted</h2>
-            <span class="govuk-heading-xl"><?php echo get_site_count(); ?></span>
-        </div>
-        <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
-            <h2 class="govuk-heading-m">Public sites</h2>
-            <span class="govuk-heading-xl"><?php echo $live_site_count; ?></span>
-        </div>
-        <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
-            <h2 class="govuk-heading-m">WordPress</h2>
-            <span class="govuk-heading-xl"><?php echo $wp_version; // get_bloginfo("version")?></span>
-        </div>
-        <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
-            <h2 class="govuk-heading-m">GDS</h2>
-            <span class="govuk-heading-xl gds-version"></span>
-        </div>
-        <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
-            <h2 class="govuk-heading-m">PHP</h2>
-            <span class="govuk-heading-xl"><?php echo phpversion(); ?></span>
-        </div>
-        <div class="govuk-grid-column-one-half-from-desktop">
-            <h2 class="govuk-heading-m">Site monitoring and performance</h2>
-            <a href="https://github.com/ministryofjustice/hale-platform/actions/workflows/cd.yaml">
-                <img src="https://github.com/ministryofjustice/hale-platform/actions/workflows/cd.yaml/badge.svg?branch=main" alt="Hale Platform Deployment">
-            </a>
-            <ul class="govuk-list">
-                <li>
-                    <a href="https://github.com/ministryofjustice/hale-platform">Hale Platform GitHub repository</a>
-                </li>
-                <li>
-                    <a href="https://grafana.live.cloud-platform.service.justice.gov.uk/d/85a562078cdf77779eaa1add43ccec1e/kubernetes-compute-resources-namespace-pods?orgId=1&refresh=10s&var-datasource=default&var-cluster=&var-namespace=hale-platform-prod">Grafana dashboard (prod)</a>
-                </li>
-                <li>
-                    <a href="https://logs.cloud-platform.service.justice.gov.uk/_dashboards/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(_source),filters:!(),index:b95d8900-dd15-11ed-87c8-170407f57c9c,interval:auto,query:(language:kuery,query:''),sort:!())">Ingress logs</a>
-                </li>
-                <li>
-                    <a href="https://cloud-platform-e218f50a4812967ba1215eaecede923f.s3.amazonaws.com/feed-parser/feeds.json">Job Feed Parser JSON</a>
-                </li>
-            </ul>    
-        </div>
-        <div class="govuk-grid-column-one-half-from-desktop">
-            <h2 class="govuk-heading-m">Next site to go live</h2>
-            <p class="govuk-body">
-                <?php echo $next_site_name;?>
-                <?php echo $next_site_abbr;?>
-            </p>
-            <p class="govuk-body">
-                <a href="<?php echo $next_site_url;?>">
-                    <?php echo $next_site_url;?>
-                </a>
-            </p>
-        </div>
+<div class="hale-dash-metrics">
+    <div class="hale-dash-metric">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Current Environment</h2>
+        <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo $this_env; ?></span>
+    </div>
+    <div class="hale-dash-metric">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Sites hosted</h2>
+        <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo get_site_count(); ?></span>
+    </div>
+    <div class="hale-dash-metric">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Public sites</h2>
+        <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo $live_site_count; ?></span>
+    </div>
+    <div class="hale-dash-metric">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">WordPress</h2>
+        <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo $wp_version; ?></span>
+    </div>
+    <div class="hale-dash-metric">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">GDS</h2>
+        <span class="govuk-heading-l govuk-!-margin-bottom-0 gds-version"></span>
+    </div>
+    <div class="hale-dash-metric">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">PHP</h2>
+        <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo phpversion(); ?></span>
+    </div>
+
+    <div class="hale-dash-metric hale-dash-metric--wide">
+        <h2 class="govuk-heading-s">Site monitoring and performance</h2>
+        <ul class="govuk-list govuk-body-s">
+            <li>
+                <a href="https://github.com/ministryofjustice/hale-platform">Hale Platform GitHub repository</a>
+            </li>
+            <li>
+                <a href="https://grafana.live.cloud-platform.service.justice.gov.uk/d/85a562078cdf77779eaa1add43ccec1e/kubernetes-compute-resources-namespace-pods?orgId=1&refresh=10s&var-datasource=default&var-cluster=&var-namespace=hale-platform-prod">Grafana dashboard (prod)</a>
+            </li>
+            <li>
+                <a href="https://logs.cloud-platform.service.justice.gov.uk/_dashboards/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(_source),filters:!(),index:b95d8900-dd15-11ed-87c8-170407f57c9c,interval:auto,query:(language:kuery,query:''),sort:!())">Ingress logs</a>
+            </li>
+            <li>
+                <a href="https://cloud-platform-e218f50a4812967ba1215eaecede923f.s3.amazonaws.com/feed-parser/feeds.json">Job Feed Parser JSON</a>
+            </li>
+        </ul>
     </div>
 </div>

--- a/components/feature-metrics.php
+++ b/components/feature-metrics.php
@@ -21,7 +21,7 @@
 
     // Users with at least one active (non-expired) session; collect IDs for per-site lookup
     $session_rows = $wpdb->get_results(
-        "SELECT user_id, meta_value FROM {$wpdb->usermeta} WHERE meta_key = 'session_tokens'"
+        $wpdb->prepare("SELECT user_id, meta_value FROM {$wpdb->usermeta} WHERE meta_key = %s", 'session_tokens')
     );
     $now = time();
     $active_user_ids = [];
@@ -41,7 +41,7 @@
 <div class="hale-dash-metrics">
     <div class="hale-dash-metric">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Current Environment</h2>
-        <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo $this_env; ?></span>
+        <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo esc_html($this_env); ?></span>
     </div>
     <div class="hale-dash-metric">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Sites hosted</h2>
@@ -53,7 +53,7 @@
     </div>
     <div class="hale-dash-metric">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-1">WordPress</h2>
-        <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo $wp_version; ?></span>
+        <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo esc_html($wp_version); ?></span>
     </div>
     <div class="hale-dash-metric">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-1">GDS</h2>

--- a/components/feature-metrics.php
+++ b/components/feature-metrics.php
@@ -55,6 +55,9 @@
             <li>
                 <a href="https://cloud-platform-e218f50a4812967ba1215eaecede923f.s3.amazonaws.com/feed-parser/feeds.json">Job Feed Parser JSON</a>
             </li>
+            <li>
+                <a href="https://websitebuilder.service.justice.gov.uk/wp-json/hc-rest/v1/sites/domain">Platform site API</a>
+            </li>
         </ul>
     </div>
 </div>

--- a/components/feature-metrics.php
+++ b/components/feature-metrics.php
@@ -40,35 +40,35 @@
 ?>
 <div class="hale-dash-metrics">
     <div class="hale-dash-metric">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Current Environment</h2>
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Current Environment</h3>
         <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo esc_html($this_env); ?></span>
     </div>
     <div class="hale-dash-metric">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Sites hosted</h2>
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Sites hosted</h3>
         <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo get_site_count(); ?></span>
     </div>
     <div class="hale-dash-metric">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Public sites</h2>
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Public sites</h3>
         <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo $live_site_count; ?></span>
     </div>
     <div class="hale-dash-metric">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">WordPress</h2>
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-1">WordPress</h3>
         <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo esc_html($wp_version); ?></span>
     </div>
     <div class="hale-dash-metric">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">GDS</h2>
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-1">GDS</h3>
         <span class="govuk-heading-l govuk-!-margin-bottom-0 gds-version"></span>
     </div>
     <div class="hale-dash-metric">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">PHP</h2>
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-1">PHP</h3>
         <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo phpversion(); ?></span>
     </div>
     <div class="hale-dash-metric">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Network users</h2>
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Network users</h3>
         <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo number_format($total_network_users); ?></span>
     </div>
     <div class="hale-dash-metric">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Logged in now</h2>
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Logged in now</h3>
         <span class="govuk-heading-l govuk-!-margin-bottom-0"><?php echo $active_sessions; ?></span>
     </div>
 

--- a/components/feature-metrics.php
+++ b/components/feature-metrics.php
@@ -73,7 +73,7 @@
     </div>
 
     <div class="hale-dash-metric hale-dash-metric--wide">
-        <h2 class="govuk-heading-s">Site monitoring and performance</h2>
+        <h2 class="govuk-heading-s">Monitoring resources</h2>
         <ul class="govuk-list govuk-body-s">
             <li>
                 <a href="https://github.com/ministryofjustice/hale-platform">Hale Platform GitHub repository</a>

--- a/components/site-status-list.php
+++ b/components/site-status-list.php
@@ -77,7 +77,7 @@ if (isset($_GET['refresh_dash']) && current_user_can('manage_network')) {
 
 $cached = get_transient($transient_key);
 if ($cached !== false) {
-    echo wp_kses_post($cached);
+    echo $cached;
     	return;
 }
 

--- a/components/site-status-list.php
+++ b/components/site-status-list.php
@@ -166,7 +166,7 @@ foreach ($sites as $site) {
             ?>
         </div>
         <?php if ($site_id != $dashboard_ID): ?>
-            <a class="website__domain govuk-link govuk-body-s" href="<?php echo esc_url($prod_url); ?>" title="<?php echo esc_attr($prod_url); ?>"><?php echo esc_html($prod_domain); ?></a>
+            <a class="website__domain govuk-link govuk-body-s" href="<?php echo esc_url($prod_url); ?>" title="<?php echo esc_attr($prod_url); ?>" target="_blank" rel="noopener noreferrer"><span class="website__domain-text"><?php echo esc_html($prod_domain); ?></span><svg class="website__domain-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></a>
         <?php endif; ?>
         <div class="website__technical">
             <?php

--- a/components/site-status-list.php
+++ b/components/site-status-list.php
@@ -84,7 +84,7 @@ foreach ($sites as $site) {
         $status = '<span class="website__up-down"><strong class="govuk-tag hale-dash-better-tag govuk-tag--red hale-dash-better-tag--red">Public</strong></span>';
     }
     ?>
-    <div class="hale-dash-site-item" data-site-name="<?php echo esc_attr(strtolower($site_name)); ?>" data-site-id="<?php echo esc_attr($site_id); ?>">
+    <div class="hale-dash-site-item" data-site-name="<?php echo esc_attr(strtolower($site_name)); ?>" data-site-id="<?php echo esc_attr($site_id); ?>" data-site-slug="<?php echo esc_attr(strtolower($site_path_slug)); ?>">
     <article class="website">
         <div class="website__heading">
             <?php

--- a/components/site-status-list.php
+++ b/components/site-status-list.php
@@ -150,6 +150,7 @@ foreach ($sites as $site) {
                     echo "<h2 class='website__heading__text govuk-heading-s'>Hale Platform Dashboard</h2>";
                     echo "<p class='govuk-body govuk-hint govuk-!-margin-bottom-0 website__explanation'>This dashboard</p>";
                 } else {
+                    echo $icon;
                     echo "<h2 " . $site_lang_attribute . " class='website__heading__text govuk-heading-s'>" . esc_html($site_name) . "</h2>";
                     $warning .= language_warning($lang);
                     $warning .= timezone_warning($timezone);

--- a/components/site-status-list.php
+++ b/components/site-status-list.php
@@ -1,6 +1,5 @@
 <?php
 $environments = [
-    'prod',
     'staging',
     'dev',
     'demo'
@@ -56,8 +55,37 @@ foreach ($sites as $site) {
     $deprecated = get_theme_mod( 'deprecated_paragraph_widths' );
     if ($lang != $main_lang) $site_lang_attribute = "lang='$lang'";
     if ($lang == "") $site_lang_attribute = "lang=en-US"; //WP uses "" to denote en-US
+
+    // Resolve the production URL / domain shown under the site title.
+    $site_path_slug = get_option('site_path_slug') ?: "";
+    if ($this_env == "Prod") {
+        $prod_url = $site_url;
+    } elseif (isset($live_urls[trim($site_name)])) {
+        $prod_url = $live_urls[trim($site_name)];
+    } else {
+        $prod_url = "https://websitebuilder.service.justice.gov.uk/$site_path_slug";
+    }
+    if (strpos($prod_url, "http") === false) {
+        $prod_url = "https://" . $prod_url;
+    }
+    $prod_domain = parse_url($prod_url, PHP_URL_HOST);
+    if ($path = parse_url($prod_url, PHP_URL_PATH)) {
+        $prod_domain .= rtrim($path, '/');
+    }
+
+    // Production status tag (was previously set inside the env loop).
+    if ($site_name == $next_site_name && ($this_env == "Prod" || $this_env == "Local")) {
+        $status = '<span class="website__up-down"><strong class="govuk-tag hale-dash-better-tag govuk-tag--turquoise">Next</strong></span>';
+    } elseif (is_plugin_active_on_site('wp-force-login/wp-force-login.php', $site_id)) {
+        $status = '<span class="website__up-down"><strong class="govuk-tag hale-dash-better-tag govuk-tag--grey">Private</strong></span>';
+    } elseif ($this_env == "Prod" || $this_env == "Local") {
+        $status = '<span class="website__up-down"><strong class="govuk-tag hale-dash-better-tag govuk-tag--blue hale-dash-better-tag--blue">Public</strong></span>';
+    } else {
+        $status = '<span class="website__up-down"><strong class="govuk-tag hale-dash-better-tag govuk-tag--red hale-dash-better-tag--red">Public</strong></span>';
+    }
     ?>
-    <div class="website">
+    <div class="hale-dash-site-item" data-site-name="<?php echo esc_attr(strtolower($site_name)); ?>" data-site-id="<?php echo esc_attr($site_id); ?>">
+    <article class="website">
         <div class="website__heading">
             <?php
                 echo $icon;
@@ -72,87 +100,10 @@ foreach ($sites as $site) {
                     $warning .= deprecated_warning($deprecated);
                 }
             ?>
-
         </div>
-        <div class="website__links govuk-body-s govuk-!-margin-bottom-0">
-            <?php
-            foreach ($environments as $env) {
-
-                $site_path_slug = "";
-
-                if (get_option('site_path_slug')) {
-                    $site_path_slug = get_option('site_path_slug');
-                }
-
-                switch ($env) {
-                    case "prod":
-                        $env_url = "https://websitebuilder.service.justice.gov.uk/$site_path_slug";
-                        break;
-                    case "local":
-                        $env_url = "https://hale.docker/$site_path_slug";
-                        break;
-                    default:
-                      $env_url = "https://$env.websitebuilder.service.justice.gov.uk/$site_path_slug";
-                }
-
-
-                ?>
-                <div class="website__environment">
-                    <?php
-                    if ($env == "prod") {
-
-                        if ($this_env == "Prod") {
-                            $env_url = $site_url;
-                        } elseif (isset($live_urls[trim($site_name)])) {
-                            // checks hard-coded list of URLs
-                            $env_url = $live_urls[trim($site_name)];
-                        }
-
-                        if ($site_name == $next_site_name && ($this_env=="Prod" || $this_env=="Local")) {
-                            // Plugin matches next site name.
-                            $status = '<span class="website__up-down"><strong class="govuk-tag hale-dash-better-tag govuk-tag--turquoise">Next</strong></span>';
-                        } elseif (is_plugin_active_on_site('wp-force-login/wp-force-login.php', $site_id)) {
-                            // Plugin is active on the specified site.
-                            $status = '<span class="website__up-down"><strong class="govuk-tag hale-dash-better-tag govuk-tag--grey">Private</strong></span>';
-                        } elseif ($this_env=="Prod" || $this_env=="Local") {
-                            // Plugin is inactive on the specified site & site is prod or local.
-                            $status = '<span class="website__up-down"><strong class="govuk-tag hale-dash-better-tag govuk-tag--blue hale-dash-better-tag--blue">Public</strong></span>';
-                        } else {
-                            // Plugin is inactive on the specified site & site is NOT prod or local.
-                            $status = '<span class="website__up-down"><strong class="govuk-tag hale-dash-better-tag govuk-tag--red hale-dash-better-tag--red">Public</strong></span>';
-                        }
-
-                        if (strpos($env_url, "http") === false) {
-                            $env_url = "https://" . $env_url;
-                        }
-                    } else {
-                        if (!is_plugin_active_on_site('wp-force-login/wp-force-login.php', $site_id)) {
-                            // Plugin is inactive on the specified site.
-                            // $warning .= ucfirst("$env environment is not password protected! <br />"); // This didn't work!
-                        }
-                    }
-
-                    // Add in the "login" link to prod
-                    $env_link = "<a href='$env_url' class='website__environment__link website__environment__link--$env govuk-link'>" . ucfirst($env) . "</a>";
-                    $login_link = "";
-
-                    if ($env == 'prod') {
-                    $login_link = " | <a href='$env_url/hale-wpms-2020'>Login</a>";
-                    echo $env_link . $login_link;
-                    } elseif ($site_path_slug == "" && $site_id != 1) {
-                        // No slug, so no useful link
-                        // Just write env name to keep alignment
-                        echo ucfirst($env) . "<!-- No slug, no link -->";
-                    } else {
-                        echo $env_link;
-                    }
-
-                    ?>
-                </div>
-                <?php
-            }
-            ?>
-        </div>
+        <?php if ($site_id != $dashboard_ID): ?>
+            <a class="website__domain govuk-link govuk-body-s" href="<?php echo $prod_url; ?>" title="<?php echo $prod_url; ?>"><?php echo $prod_domain; ?></a>
+        <?php endif; ?>
         <div class="website__users govuk-body-s govuk-!-margin-bottom-0">
             <?php
                 echo $status;
@@ -164,18 +115,38 @@ foreach ($sites as $site) {
                 }
             ?>
         </div>
-        <div class='website__technical govuk-body-s govuk-!-margin-bottom-0'>
-            <?php
-                if ($site_path_slug != "") echo "<h2 class='website__slug-title'>Slug</h2> <code class='website__slug'>$site_path_slug</code> <br /> ";
-                echo "<h2 class='website__id-title'>ID</h2> <span class='website_id'>$site_id</span>";
-            ?>
+        <div class="website__footer govuk-body-s">
+            <div class='website__technical govuk-!-margin-bottom-0'>
+                <?php
+                    if ($site_path_slug != "") echo "<h2 class='website__slug-title'>Slug</h2> <code class='website__slug'>$site_path_slug</code>";
+                    echo "<h2 class='website__id-title'>ID</h2> <span class='website_id'>$site_id</span>";
+                ?>
+            </div>
+            <div class="website__links govuk-!-margin-bottom-0">
+                <?php
+                foreach ($environments as $env) {
+                    switch ($env) {
+                        case "local":
+                            $env_url = "https://hale.docker/$site_path_slug";
+                            break;
+                        default:
+                            $env_url = "https://$env.websitebuilder.service.justice.gov.uk/$site_path_slug";
+                    }
+
+                    if ($site_path_slug == "" && $site_id != 1) {
+                        echo "<span class='website__environment website__environment--disabled website__environment--$env'>" . ucfirst($env) . "</span>";
+                    } else {
+                        echo "<a href='$env_url' class='website__environment website__environment--$env govuk-link'>" . ucfirst($env) . "</a>";
+                    }
+                }
+                ?>
+            </div>
         </div>
+    </article>
+    <?php if ($warning): ?>
+        <div class="website__warning"><?php echo $warning; ?></div>
+    <?php endif; ?>
     </div>
-    <?php
-        if ($warning) {
-            echo "<div class='website__warning'>$warning</div>";
-        }
-    ?>
 
     <?php
     restore_current_blog();

--- a/components/site-status-list.php
+++ b/components/site-status-list.php
@@ -77,8 +77,8 @@ if (isset($_GET['refresh_dash']) && current_user_can('manage_network')) {
 
 $cached = get_transient($transient_key);
 if ($cached !== false) {
-    echo $cached;
-    return;
+    echo wp_kses_post($cached);
+    	return;
 }
 
 ob_start();
@@ -96,8 +96,8 @@ foreach ($sites as $site) {
     $warning = "";
     $theme = get_option('stylesheet');
     $deprecated = get_theme_mod('deprecated_paragraph_widths');
-    if ($lang != $main_lang) $site_lang_attribute = "lang='$lang'";
-    if ($lang == "") $site_lang_attribute = "lang=en-US";
+    if ($lang != $main_lang) $site_lang_attribute = "lang='" . esc_attr($lang) . "'";
+    if ($lang == "") $site_lang_attribute = "lang='en-US'";
 
     // Resolve the production URL / domain shown under the site title.
     $site_path_slug = get_option('site_path_slug') ?: "";
@@ -146,12 +146,11 @@ foreach ($sites as $site) {
     <article class="website">
         <div class="website__heading">
             <?php
-                echo $icon;
                 if ($site_id == $dashboard_ID) {
                     echo "<h2 class='website__heading__text govuk-heading-s'>Hale Platform Dashboard</h2>";
                     echo "<p class='govuk-body govuk-hint govuk-!-margin-bottom-0 website__explanation'>This dashboard</p>";
                 } else {
-                    echo "<h2 $site_lang_attribute class='website__heading__text govuk-heading-s'>$site_name</h2>";
+                    echo "<h2 " . $site_lang_attribute . " class='website__heading__text govuk-heading-s'>" . esc_html($site_name) . "</h2>";
                     $warning .= language_warning($lang);
                     $warning .= timezone_warning($timezone);
                     $warning .= theme_warning($theme);
@@ -160,25 +159,25 @@ foreach ($sites as $site) {
             ?>
         </div>
         <?php if ($site_id != $dashboard_ID): ?>
-            <a class="website__domain govuk-link govuk-body-s" href="<?php echo $prod_url; ?>" title="<?php echo $prod_url; ?>"><?php echo $prod_domain; ?></a>
+            <a class="website__domain govuk-link govuk-body-s" href="<?php echo esc_url($prod_url); ?>" title="<?php echo esc_attr($prod_url); ?>"><?php echo esc_html($prod_domain); ?></a>
         <?php endif; ?>
         <div class="website__users govuk-body-s govuk-!-margin-bottom-0">
             <?php
                 echo $status;
-                if ($user_count && $user_count <= 1000) echo "<br />$user_count users";
-                if ($user_count && $user_count > 1000) {
-                    $user_count_text = number_format((float)($user_count/1000), 1, '.', '').'k';
-                    echo "<br />$user_count_text users";
-                }
-                $site_logged_in = $site_active_counts[$site_id] ?? 0;
-                if ($site_logged_in > 0) echo "<span class='website__online-count'>$site_logged_in online</span>";
+                if ($user_count && $user_count <= 1000) echo "<br />" . intval($user_count) . " users";
+                				if ($user_count && $user_count > 1000) {
+                					$user_count_text = number_format((float)($user_count/1000), 1, '.', '').'k';
+                					echo "<br />" . esc_html($user_count_text) . " users";
+                				}
+                				$site_logged_in = (int) ($site_active_counts[$site_id] ?? 0);
+                				if ($site_logged_in > 0) echo "<span class='website__online-count'>" . intval($site_logged_in) . " online</span>";
             ?>
         </div>
         <div class="website__footer govuk-body-s">
             <div class='website__technical govuk-!-margin-bottom-0'>
                 <?php
-                    if ($site_path_slug != "") echo "<h2 class='website__slug-title'>Slug</h2> <code class='website__slug'>$site_path_slug</code>";
-                    echo "<h2 class='website__id-title'>ID</h2> <span class='website_id'>$site_id</span>";
+                    if ($site_path_slug != "") echo "<h2 class='website__slug-title'>Slug</h2> <code class='website__slug'>" . esc_html($site_path_slug) . "</code>";
+                    echo "<h2 class='website__id-title'>ID</h2> <span class='website_id'>" . intval($site_id) . "</span>";
                 ?>
             </div>
             <div class="website__links govuk-!-margin-bottom-0">
@@ -193,9 +192,9 @@ foreach ($sites as $site) {
                     }
 
                     if ($site_path_slug == "" && $site_id != 1) {
-                        echo "<span class='website__environment website__environment--disabled website__environment--$env'>" . ucfirst($env) . "</span>";
+                        echo "<span class='website__environment website__environment--disabled website__environment--" . esc_attr($env) . "'>" . esc_html(ucfirst($env)) . "</span>";
                     } else {
-                        echo "<a href='$env_url' class='website__environment website__environment--$env govuk-link'>" . ucfirst($env) . "</a>";
+                        echo "<a href='" . esc_url($env_url) . "' class='website__environment website__environment--" . esc_attr($env) . " govuk-link'>" . esc_html(ucfirst($env)) . "</a>";
                     }
                 }
                 ?>

--- a/components/site-status-list.php
+++ b/components/site-status-list.php
@@ -154,11 +154,11 @@ foreach ($sites as $site) {
         <div class="website__heading">
             <?php
                 if ($site_id == $dashboard_ID) {
-                    echo "<h2 class='website__heading__text govuk-heading-s'>Hale Platform Dashboard</h2>";
+                    echo "<h3 class='website__heading__text govuk-heading-s'>Hale Platform Dashboard</h3>";
                     echo "<p class='govuk-body govuk-hint govuk-!-margin-bottom-0 website__explanation'>This dashboard</p>";
                 } else {
                     echo $icon;
-                    echo "<h2 " . $site_lang_attribute . " class='website__heading__text govuk-heading-s'>" . esc_html($site_name) . "</h2>";
+                    echo "<h3 " . $site_lang_attribute . " class='website__heading__text govuk-heading-s'>" . esc_html($site_name) . "</h3>";
                     $warning .= language_warning($lang);
                     $warning .= timezone_warning($timezone);
                     $warning .= theme_warning($theme);
@@ -184,8 +184,8 @@ foreach ($sites as $site) {
         <div class="website__footer govuk-body-s">
             <div class='website__technical govuk-!-margin-bottom-0'>
                 <?php
-                    if ($site_path_slug != "") echo "<h2 class='website__slug-title'>Slug</h2> <code class='website__slug'>" . esc_html($site_path_slug) . "</code>";
-                    echo "<h2 class='website__id-title'>ID</h2> <span class='website_id'>" . intval($site_id) . "</span>";
+                    if ($site_path_slug != "") echo "<span class='website__slug-title'>Slug</span> <code class='website__slug'>" . esc_html($site_path_slug) . "</code>";
+                    echo "<span class='website__id-title'>ID</span> <span class='website_id'>" . intval($site_id) . "</span>";
                 ?>
             </div>
             <div class="website__links govuk-!-margin-bottom-0">

--- a/components/site-status-list.php
+++ b/components/site-status-list.php
@@ -68,10 +68,17 @@ if (!empty($active_user_ids)) {
     }
 }
 
-$transient_key = 'hale_dash_sites_' . sanitize_key($this_env);
+$transient_key             = 'hale_dash_sites_' . sanitize_key($this_env);
+$refresh_dash_nonce_action = 'refresh_dash_' . $transient_key;
 
-// Allow cache busting via URL param (admins only)
-if (isset($_GET['refresh_dash']) && current_user_can('manage_network')) {
+// Allow cache busting for network admins only, but require POST + nonce to prevent CSRF.
+if (
+    isset($_SERVER['REQUEST_METHOD']) &&
+    $_SERVER['REQUEST_METHOD'] === 'POST' &&
+    isset($_POST['refresh_dash'], $_POST['refresh_dash_nonce']) &&
+    current_user_can('manage_network') &&
+    wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['refresh_dash_nonce'])), $refresh_dash_nonce_action)
+) {
     delete_transient($transient_key);
 }
 

--- a/components/site-status-list.php
+++ b/components/site-status-list.php
@@ -8,7 +8,6 @@ $environments = [
 $dashboard_ID = "59";
 
 if ($this_env == "Local") {
-    // set in feature-metrics.php
     $environments[] = "local";
 }
 
@@ -40,6 +39,50 @@ function get_live_urls() {
 $live_urls = get_live_urls();
 $this_url = get_bloginfo('url');
 
+global $wpdb;
+
+// Build a site_id => logged-in count map from the active user IDs already resolved
+// in feature-metrics.php — one batch query across all sites, no per-site loop needed.
+$site_active_counts = [];
+if (!empty($active_user_ids)) {
+    $placeholders = implode(',', array_fill(0, count($active_user_ids), '%d'));
+    $base         = $wpdb->base_prefix;
+    $rows = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT user_id, meta_key FROM {$wpdb->usermeta}
+             WHERE meta_key LIKE %s
+             AND user_id IN ($placeholders)",
+            array_merge([$wpdb->esc_like($base) . '%capabilities'], $active_user_ids)
+        )
+    );
+    foreach ($rows as $row) {
+        $key = $row->meta_key;
+        if ($key === $base . 'capabilities') {
+            $bid = 1;
+        } elseif (preg_match('/^' . preg_quote($base, '/') . '(\d+)_capabilities$/', $key, $m)) {
+            $bid = (int) $m[1];
+        } else {
+            continue;
+        }
+        $site_active_counts[$bid] = ($site_active_counts[$bid] ?? 0) + 1;
+    }
+}
+
+$transient_key = 'hale_dash_sites_' . sanitize_key($this_env);
+
+// Allow cache busting via URL param (admins only)
+if (isset($_GET['refresh_dash']) && current_user_can('manage_network')) {
+    delete_transient($transient_key);
+}
+
+$cached = get_transient($transient_key);
+if ($cached !== false) {
+    echo $cached;
+    return;
+}
+
+ob_start();
+
 foreach ($sites as $site) {
     $site_id = $site->blog_id;
     $site_url = get_site_url($site_id);
@@ -51,10 +94,10 @@ foreach ($sites as $site) {
     $main_lang = get_locale();
     $site_lang_attribute = "";
     $warning = "";
-    $theme = get_option( 'stylesheet' );
-    $deprecated = get_theme_mod( 'deprecated_paragraph_widths' );
+    $theme = get_option('stylesheet');
+    $deprecated = get_theme_mod('deprecated_paragraph_widths');
     if ($lang != $main_lang) $site_lang_attribute = "lang='$lang'";
-    if ($lang == "") $site_lang_attribute = "lang=en-US"; //WP uses "" to denote en-US
+    if ($lang == "") $site_lang_attribute = "lang=en-US";
 
     // Resolve the production URL / domain shown under the site title.
     $site_path_slug = get_option('site_path_slug') ?: "";
@@ -73,10 +116,25 @@ foreach ($sites as $site) {
         $prod_domain .= rtrim($path, '/');
     }
 
-    // Production status tag (was previously set inside the env loop).
+    // COUNT query is far cheaper than count_users() which fetches all rows
+    $blog_prefix = $wpdb->get_blog_prefix($site_id);
+    $user_count  = (int) $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT COUNT(*) FROM {$wpdb->usermeta} WHERE meta_key = %s",
+            $blog_prefix . 'capabilities'
+        )
+    );
+
+    // Active plugins already loaded into WP option cache by the switch above
+    $active_plugins = (array) get_option('active_plugins');
+    $is_private = in_array('wp-force-login/wp-force-login.php', $active_plugins);
+
+    restore_current_blog();
+
+    // Production status tag
     if ($site_name == $next_site_name && ($this_env == "Prod" || $this_env == "Local")) {
         $status = '<span class="website__up-down"><strong class="govuk-tag hale-dash-better-tag govuk-tag--turquoise">Next</strong></span>';
-    } elseif (is_plugin_active_on_site('wp-force-login/wp-force-login.php', $site_id)) {
+    } elseif ($is_private) {
         $status = '<span class="website__up-down"><strong class="govuk-tag hale-dash-better-tag govuk-tag--grey">Private</strong></span>';
     } elseif ($this_env == "Prod" || $this_env == "Local") {
         $status = '<span class="website__up-down"><strong class="govuk-tag hale-dash-better-tag govuk-tag--blue hale-dash-better-tag--blue">Public</strong></span>';
@@ -107,12 +165,13 @@ foreach ($sites as $site) {
         <div class="website__users govuk-body-s govuk-!-margin-bottom-0">
             <?php
                 echo $status;
-                $user_count = count_users()['total_users'];
                 if ($user_count && $user_count <= 1000) echo "<br />$user_count users";
                 if ($user_count && $user_count > 1000) {
                     $user_count_text = number_format((float)($user_count/1000), 1, '.', '').'k';
                     echo "<br />$user_count_text users";
                 }
+                $site_logged_in = $site_active_counts[$site_id] ?? 0;
+                if ($site_logged_in > 0) echo "<span class='website__online-count'>$site_logged_in online</span>";
             ?>
         </div>
         <div class="website__footer govuk-body-s">
@@ -149,5 +208,8 @@ foreach ($sites as $site) {
     </div>
 
     <?php
-    restore_current_blog();
 }
+
+$output = ob_get_clean();
+set_transient($transient_key, $output, 5 * MINUTE_IN_SECONDS);
+echo $output;

--- a/components/site-status-list.php
+++ b/components/site-status-list.php
@@ -157,7 +157,6 @@ foreach ($sites as $site) {
                     echo "<h3 class='website__heading__text govuk-heading-s'>Hale Platform Dashboard</h3>";
                     echo "<p class='govuk-body govuk-hint govuk-!-margin-bottom-0 website__explanation'>This dashboard</p>";
                 } else {
-                    echo $icon;
                     echo "<h3 " . $site_lang_attribute . " class='website__heading__text govuk-heading-s'>" . esc_html($site_name) . "</h3>";
                     $warning .= language_warning($lang);
                     $warning .= timezone_warning($timezone);
@@ -169,26 +168,27 @@ foreach ($sites as $site) {
         <?php if ($site_id != $dashboard_ID): ?>
             <a class="website__domain govuk-link govuk-body-s" href="<?php echo esc_url($prod_url); ?>" title="<?php echo esc_attr($prod_url); ?>"><?php echo esc_html($prod_domain); ?></a>
         <?php endif; ?>
+        <div class="website__technical">
+            <?php
+                if ($site_path_slug != "") echo "<span class='website__slug-title'>Slug</span> <code class='website__slug'>" . esc_html($site_path_slug) . "</code>";
+                echo "<span class='website__id-title'>ID</span> <span class='website_id'>" . intval($site_id) . "</span>";
+                if ($user_count) {
+                    $display_count = $user_count > 1000
+                        ? number_format((float)($user_count / 1000), 1, '.', '') . 'k'
+                        : intval($user_count);
+                    echo "<span class='website__users-title'>Users</span> <span class='website__user-count'>" . esc_html($display_count) . "</span>";
+                }
+            ?>
+        </div>
         <div class="website__users govuk-body-s govuk-!-margin-bottom-0">
             <?php
                 echo $status;
-                if ($user_count && $user_count <= 1000) echo "<br />" . intval($user_count) . " users";
-                				if ($user_count && $user_count > 1000) {
-                					$user_count_text = number_format((float)($user_count/1000), 1, '.', '').'k';
-                					echo "<br />" . esc_html($user_count_text) . " users";
-                				}
-                				$site_logged_in = (int) ($site_active_counts[$site_id] ?? 0);
-                				if ($site_logged_in > 0) echo "<span class='website__online-count'>" . intval($site_logged_in) . " online</span>";
+                $site_logged_in = (int) ($site_active_counts[$site_id] ?? 0);
+                if ($site_logged_in > 0) echo "<span class='website__online-count'>" . intval($site_logged_in) . " online</span>";
             ?>
         </div>
         <div class="website__footer govuk-body-s">
-            <div class='website__technical govuk-!-margin-bottom-0'>
-                <?php
-                    if ($site_path_slug != "") echo "<span class='website__slug-title'>Slug</span> <code class='website__slug'>" . esc_html($site_path_slug) . "</code>";
-                    echo "<span class='website__id-title'>ID</span> <span class='website_id'>" . intval($site_id) . "</span>";
-                ?>
-            </div>
-            <div class="website__links govuk-!-margin-bottom-0">
+            <div class="website__links">
                 <?php
                 foreach ($environments as $env) {
                     switch ($env) {

--- a/front-page.php
+++ b/front-page.php
@@ -18,12 +18,12 @@ $sites = get_sites();
 <div class="govuk-grid-column-full">
     <div class="govuk-grid-row hale-dash-layout">
         <aside class="govuk-grid-column-one-third hale-dash-metrics-col">
-            <h1 class="govuk-heading-l">Platform metrics</h1>
+            <h2 class="govuk-heading-l">Platform metrics</h2>
             <?php include get_stylesheet_directory() . '/components/feature-metrics.php'; ?>
         </aside>
 
         <section class="govuk-grid-column-two-thirds hale-dash-sites-col">
-            <h1 class="govuk-heading-l">Sites</h1>
+            <h2 class="govuk-heading-l">Sites</h2>
             <div class="hale-dash-search">
                 <div class="hale-dash-search__field hale-dash-search__field--name">
                     <label class="govuk-label govuk-label--s" for="hd-search-name">Search by name</label>

--- a/front-page.php
+++ b/front-page.php
@@ -25,13 +25,17 @@ $sites = get_sites();
         <section class="govuk-grid-column-two-thirds hale-dash-sites-col">
             <h1 class="govuk-heading-l">Sites</h1>
             <div class="hale-dash-search">
-                <div class="hale-dash-search__field">
+                <div class="hale-dash-search__field hale-dash-search__field--name">
                     <label class="govuk-label govuk-label--s" for="hd-search-name">Search by name</label>
                     <input class="govuk-input" type="search" id="hd-search-name" placeholder="e.g. Law Commission" autocomplete="off">
                 </div>
                 <div class="hale-dash-search__field">
                     <label class="govuk-label govuk-label--s" for="hd-search-id">Search by ID</label>
                     <input class="govuk-input hale-dash-search__id-input" type="search" id="hd-search-id" placeholder="e.g. 42" inputmode="numeric" autocomplete="off">
+                </div>
+                <div class="hale-dash-search__field">
+                    <label class="govuk-label govuk-label--s" for="hd-search-slug">Search by slug</label>
+                    <input class="govuk-input" type="search" id="hd-search-slug" placeholder="e.g. lawcom" autocomplete="off">
                 </div>
                 <p class="hale-dash-search__count govuk-body-s govuk-hint" id="hd-search-count" aria-live="polite"></p>
             </div>

--- a/front-page.php
+++ b/front-page.php
@@ -15,17 +15,30 @@ echo getBrithday();
 $sites = get_sites();
 ?>
 
-<div class="govuk-grid-column-full govuk-!-margin-top-6">
-    <h1 class="govuk-heading-l is-style-wide">Platform metrics</h1>
-</div>
+<div class="govuk-grid-column-full">
+    <div class="govuk-grid-row hale-dash-layout">
+        <aside class="govuk-grid-column-one-third hale-dash-metrics-col">
+            <h1 class="govuk-heading-l">Platform metrics</h1>
+            <?php include get_stylesheet_directory() . '/components/feature-metrics.php'; ?>
+        </aside>
 
-<main class="govuk-main-wrapper">
-    <?php include get_stylesheet_directory() . '/components/feature-metrics.php'; ?>
-
-    <div class="govuk-grid-column-full">
-        <?php include get_stylesheet_directory() . '/components/site-status-list.php'; ?>
+        <section class="govuk-grid-column-two-thirds hale-dash-sites-col">
+            <h1 class="govuk-heading-l">Sites</h1>
+            <div class="hale-dash-search">
+                <div class="hale-dash-search__field">
+                    <label class="govuk-label govuk-label--s" for="hd-search-name">Search by name</label>
+                    <input class="govuk-input" type="search" id="hd-search-name" placeholder="e.g. Law Commission" autocomplete="off">
+                </div>
+                <div class="hale-dash-search__field">
+                    <label class="govuk-label govuk-label--s" for="hd-search-id">Search by ID</label>
+                    <input class="govuk-input hale-dash-search__id-input" type="search" id="hd-search-id" placeholder="e.g. 42" inputmode="numeric" autocomplete="off">
+                </div>
+                <p class="hale-dash-search__count govuk-body-s govuk-hint" id="hd-search-count" aria-live="polite"></p>
+            </div>
+            <?php include get_stylesheet_directory() . '/components/site-status-list.php'; ?>
+        </section>
     </div>
-</main>
+</div>
 
 <?php
 get_footer();

--- a/functions.php
+++ b/functions.php
@@ -18,6 +18,30 @@ function hale_dash_setup() {}
 
 add_action('after_setup_theme', 'hale_dash_setup');
 
+/**
+ * Inherit parent theme mods so logo/header/footer settings carry through.
+ * Falls back to showing site name if logo_configuration is still unset.
+ */
+add_filter('get_theme_mods', function ($mods) {
+    $parent_slug = get_template();
+    $parent_mods = get_option('theme_mods_' . $parent_slug, []);
+
+    if (is_array($parent_mods)) {
+        foreach ($parent_mods as $key => $value) {
+            if (!array_key_exists($key, $mods) || $mods[$key] === '') {
+                $mods[$key] = $value;
+            }
+        }
+    }
+
+    // Hard fallback: if logo_configuration is still not set, show the site name.
+    if (empty($mods['logo_configuration'])) {
+        $mods['logo_configuration'] = 'name';
+    }
+
+    return $mods;
+});
+
 function hale_dash_enqueue_styles() {
 	wp_enqueue_style( 'hale-dash-style',
         hale_dash_mix_asset('/css/hale-dash-style.min.css'),

--- a/functions.php
+++ b/functions.php
@@ -68,6 +68,7 @@ add_action( 'wp_enqueue_scripts', 'hale_dash_enqueue_styles' );
 
 /**
  * Inline script in <head> to set theme before first paint (avoids FOUC).
+ * The script must be inline in the <head> rather than loaded from an external file because external scripts require an extra network request, during which the browser would paint the page in its default (light) state first.
  */
 function hale_dash_dark_mode_inline() {
 	?>

--- a/functions.php
+++ b/functions.php
@@ -24,9 +24,52 @@ function hale_dash_enqueue_styles() {
 		array( 'hale-style' ),
 		wp_get_theme()->get( 'Version' )
 	);
+
+	wp_enqueue_script( 'hale-dash-dark-mode',
+		get_theme_file_uri() . '/dist/js/dark-mode.js',
+		array(),
+		wp_get_theme()->get( 'Version' ),
+		false
+	);
+
+	wp_enqueue_script( 'hale-dash-search',
+		get_theme_file_uri() . '/dist/js/search.js',
+		array(),
+		wp_get_theme()->get( 'Version' ),
+		true
+	);
 }
 
 add_action( 'wp_enqueue_scripts', 'hale_dash_enqueue_styles' );
+
+/**
+ * Inline script in <head> to set theme before first paint (avoids FOUC).
+ */
+function hale_dash_dark_mode_inline() {
+	?>
+	<script>
+	(function(){try{var s=localStorage.getItem('hd-theme');var d=s==='dark'||(!s&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);if(d)document.documentElement.setAttribute('data-theme','dark');}catch(e){}})();
+	</script>
+	<?php
+}
+add_action( 'wp_head', 'hale_dash_dark_mode_inline', 1 );
+
+/**
+ * Render dark mode toggle at the bottom of every page.
+ */
+function hale_dash_dark_mode_toggle() {
+	?>
+	<div class="hd-theme-toggle-wrap govuk-width-container">
+		<button type="button" class="hd-theme-toggle" aria-pressed="false">
+			<svg class="hd-theme-toggle__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+				<path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/>
+			</svg>
+			<span class="hd-theme-toggle__label">Switch to dark mode</span>
+		</button>
+	</div>
+	<?php
+}
+add_action( 'wp_footer', 'hale_dash_dark_mode_toggle' );
 
 /**
  * Gett asset path function

--- a/functions.php
+++ b/functions.php
@@ -80,18 +80,19 @@ function hale_dash_dark_mode_inline() {
 add_action( 'wp_head', 'hale_dash_dark_mode_inline', 1 );
 
 /**
- * Render dark mode toggle at the bottom of every page.
+ * Render dark mode toggle — JS moves it into the header on load.
  */
 function hale_dash_dark_mode_toggle() {
 	?>
-	<div class="hd-theme-toggle-wrap govuk-width-container">
-		<button type="button" class="hd-theme-toggle" aria-pressed="false">
-			<svg class="hd-theme-toggle__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-				<path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/>
-			</svg>
-			<span class="hd-theme-toggle__label">Switch to dark mode</span>
-		</button>
-	</div>
+	<button type="button" class="hd-theme-toggle" role="switch" aria-checked="false" aria-label="Toggle dark mode">
+		<svg class="hd-theme-toggle__icon hd-theme-toggle__icon--sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+			<path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.414a.5.5 0 1 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708"/>
+		</svg>
+		<span class="hd-theme-toggle__track"><span class="hd-theme-toggle__thumb"></span></span>
+		<svg class="hd-theme-toggle__icon hd-theme-toggle__icon--moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+			<path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/>
+		</svg>
+	</button>
 	<?php
 }
 add_action( 'wp_footer', 'hale_dash_dark_mode_toggle' );

--- a/functions.php
+++ b/functions.php
@@ -124,7 +124,7 @@ function get_fav_icon($src) {
         </svg>';
     };
 
-    return '<img class="website__favicon" src="' . $src . '" alt=""/>';
+    return '<img class="website__favicon" src="' . esc_url($src) . '" alt=""/>';
 }
 
 /**
@@ -164,9 +164,9 @@ function language_warning($code) {
     } elseif ($code == "en_AU") {
         return "<p><span><strong class='govuk-tag hale-dash-better-tag govuk-tag--orange'>Localization</strong></span> This website is set to <strong>Australian English</strong> 🇦🇺</p>";
     } elseif (!str_starts_with($code, "en")) {
-        return "<p><span><strong class='govuk-tag hale-dash-better-tag govuk-tag--red hale-dash-better-tag--red'>Language</strong></span> This website is set to <strong>$code</strong>.</p>";
+        return "<p><span><strong class='govuk-tag hale-dash-better-tag govuk-tag--red hale-dash-better-tag--red'>Language</strong></span> This website is set to <strong>" . esc_html($code) . "</strong>.</p>";
     } elseif ($code != "en_GB") {
-        return "<p><span><strong class='govuk-tag hale-dash-better-tag govuk-tag--orange'>Localization</strong></span> This website is set to <strong>$code</strong>.</p>";
+        return "<p><span><strong class='govuk-tag hale-dash-better-tag govuk-tag--orange'>Localization</strong></span> This website is set to <strong>" . esc_html($code) . "</strong>.</p>";
     }
 }
 
@@ -191,13 +191,13 @@ function timezone_warning($zone) {
     } elseif ($zone == "Atlantic/Canary") {
         return "<p><strong class='govuk-tag hale-dash-better-tag govuk-tag--yellow'>Timezone</strong></span> This website is set to the <strong>Canarian</strong> timezone.</p>";
     } else {
-        return "<p><strong class='govuk-tag hale-dash-better-tag govuk-tag--red'>Timezone</strong></span> This website is set to the <strong>$zone</strong> timezone. <br />(Scheduling accuracy might be adversely affected.)</p>";
+        return "<p><strong class='govuk-tag hale-dash-better-tag govuk-tag--red'>Timezone</strong></span> This website is set to the <strong>" . esc_html($zone) . "</strong> timezone. <br />(Scheduling accuracy might be adversely affected.)</p>";
     }
 }
 
 function theme_warning($theme) {
     if ($theme == "hale")  return "";
-    return "<p><strong class='govuk-tag hale-dash-better-tag govuk-tag--yellow'>Non-Hale</strong></span> This website is using the <strong>$theme</strong> theme.</p>";
+    return "<p><strong class='govuk-tag hale-dash-better-tag govuk-tag--yellow'>Non-Hale</strong></span> This website is using the <strong>" . esc_html($theme) . "</strong> theme.</p>";
 }
 
 function deprecated_warning($deprecated) {

--- a/inc/notification-banner.php
+++ b/inc/notification-banner.php
@@ -142,11 +142,11 @@ function getBrithday() {
                     </h2>
                 </div>
                 <div class="govuk-notification-banner__content">
-                <div class="birthday-logo" style="background-image:url(https://hale.docker/wp-content/themes/hale-dash/assets/images/marc.png);"></div>
+                <div class="birthday-logo" style="background-image:url(' . esc_url(get_theme_file_uri('/assets/images/marc.png')) . ');"></div>
                     <h3 class="govuk-notification-banner__heading" style="display:inline-block;">
                         '.$greeting.'
                     </h3>
-                    <div class="birthday-logo" style="background-image:url(https://hale.docker/wp-content/themes/hale-dash/assets/images/marc.png);"></div>
+                    <div class="birthday-logo" style="background-image:url(' . esc_url(get_theme_file_uri('/assets/images/marc.png')) . ');"></div>
                 </div>
             </div>
         </div>

--- a/inc/notification-banner.php
+++ b/inc/notification-banner.php
@@ -107,7 +107,7 @@ function festiveGreeting($now) {
     }
     if ($greeting !="") {
         $greeting = '
-    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+    <div class="govuk-grid-column-two-thirds">
         <div class="govuk-notification-banner govuk-notification-banner--success"
             aria-labelledby="govuk-notification-banner-title"
             data-module="govuk-notification-banner">
@@ -132,7 +132,7 @@ function getBrithday() {
     if (in_array(get_current_user_id(),[2,26,34,49]) && date("nd",time()) == 1011) {
         $greeting = "Happy Birthday Marc";
     return '
-        <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+        <div class="govuk-grid-column-two-thirds">
             <div class="govuk-notification-banner govuk-notification-banner--success"
                 aria-labelledby="govuk-notification-banner-title"
                 data-module="govuk-notification-banner">

--- a/partials/logo.php
+++ b/partials/logo.php
@@ -41,7 +41,7 @@ $show_sitename = in_array($logo_configuration, ['name', 'both']) ? 'yes' : 'yes'
 <div class="govuk-header__logo">
     <?php if ($logo_has_link === 'yes'): ?>
     <a class="govuk-header__link govuk-header__link--homepage"
-       href="<?php echo esc_url_raw($logo_link); ?>"
+       href="<?php echo esc_url($logo_link); ?>"
        aria-label="<?php echo esc_attr($logo_aria_label); ?>">
     <?php endif; ?>
 

--- a/partials/logo.php
+++ b/partials/logo.php
@@ -55,7 +55,7 @@ $show_sitename = in_array($logo_configuration, ['name', 'both']) ? 'yes' : 'yes'
                 <svg role="presentation" focusable="false" class="moj-header__logotype-crest"
                      xmlns="http://www.w3.org/2000/svg" viewBox="0 0 702.47 624.08" height="40" width="47">
                     <?php include get_template_directory() . '/partials/govuk-crest-svg-content.php'; ?>
-                    <image src="/assets/images/gov-crest-white.png" xlink:href=""
+                    <image src="<?php echo esc_url(get_theme_file_uri('/assets/images/gov-crest-white.png')); ?>" xlink:href=""
                            class="govuk-header__logotype-crown-fallback-image"
                            width="702.47" height="624.08"></image>
                 </svg>

--- a/partials/logo.php
+++ b/partials/logo.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Logo partial — hale-dash child theme override.
+ *
+ * Renders the site name unconditionally so the dashboard header is always
+ * visible regardless of whether logo_configuration is set on this child theme.
+ * Falls back to parent theme mods where available.
+ */
+
+$parent_mods      = get_option('theme_mods_' . get_template(), []);
+$child_mods       = get_option('theme_mods_' . get_stylesheet(), []);
+
+// Merge: child overrides parent for any key that is explicitly set and non-empty.
+$all_mods = is_array($parent_mods) ? $parent_mods : [];
+if (is_array($child_mods)) {
+    foreach ($child_mods as $key => $value) {
+        if ($value !== '' && $value !== false && $value !== null) {
+            $all_mods[$key] = $value;
+        }
+    }
+}
+
+$logo_has_link    = isset($all_mods['logo_has_link'])    ? $all_mods['logo_has_link']    : 'yes';
+$logo_custom_link = isset($all_mods['logo_custom_link']) ? $all_mods['logo_custom_link'] : '';
+$org_name_checkbox = isset($all_mods['org_name_checkbox']) ? $all_mods['org_name_checkbox'] : 'no';
+$org_name_field   = isset($all_mods['org_name_field'])   ? $all_mods['org_name_field']   : '';
+$logo_aria_label  = isset($all_mods['logo_aria_label'])  ? $all_mods['logo_aria_label']
+                    : get_bloginfo('name') . ' ' . __('homepage', 'hale');
+
+$logo_line_1 = ('yes' === $org_name_checkbox && !empty($org_name_field))
+    ? $org_name_field
+    : get_bloginfo('name');
+
+$logo_link = !empty($logo_custom_link) ? $logo_custom_link : get_home_url();
+
+$show_custom_logo = has_custom_logo();
+$logo_configuration = isset($all_mods['logo_configuration']) ? $all_mods['logo_configuration'] : 'name';
+$show_sitelogo = in_array($logo_configuration, ['logo', 'both']) ? 'yes' : '';
+$show_sitename = in_array($logo_configuration, ['name', 'both']) ? 'yes' : 'yes'; // always show name
+?>
+<div class="govuk-header__logo">
+    <?php if ($logo_has_link === 'yes'): ?>
+    <a class="govuk-header__link govuk-header__link--homepage"
+       href="<?php echo esc_url_raw($logo_link); ?>"
+       aria-label="<?php echo esc_attr($logo_aria_label); ?>">
+    <?php endif; ?>
+
+    <div class="govuk-header__logotype <?php echo $show_sitelogo === 'yes' ? '' : 'hale-header__logotype--no-logo'; ?>">
+        <?php if ($show_sitelogo === 'yes'): ?>
+            <?php if ($show_custom_logo): ?>
+                <div class="hale-header__logo--custom">
+                    <?php echo wp_get_attachment_image(get_theme_mod('custom_logo'), 'full'); ?>
+                </div>
+            <?php else: ?>
+                <svg role="presentation" focusable="false" class="moj-header__logotype-crest"
+                     xmlns="http://www.w3.org/2000/svg" viewBox="0 0 702.47 624.08" height="40" width="47">
+                    <?php include get_template_directory() . '/partials/govuk-crest-svg-content.php'; ?>
+                    <image src="/assets/images/gov-crest-white.png" xlink:href=""
+                           class="govuk-header__logotype-crown-fallback-image"
+                           width="702.47" height="624.08"></image>
+                </svg>
+            <?php endif; ?>
+        <?php endif; ?>
+
+        <span class="govuk-header__logotype-text hale-header__logotype-text--custom">
+            <?php echo esc_html($logo_line_1); ?>
+        </span>
+    </div>
+
+    <?php if ($logo_has_link === 'yes'): ?>
+    </a>
+    <?php endif; ?>
+</div>

--- a/partials/logo.php
+++ b/partials/logo.php
@@ -62,9 +62,9 @@ $show_sitename = in_array($logo_configuration, ['name', 'both']) ? 'yes' : 'yes'
             <?php endif; ?>
         <?php endif; ?>
 
-        <span class="govuk-header__logotype-text hale-header__logotype-text--custom">
+        <h1 class="govuk-header__logotype-text hale-header__logotype-text--custom">
             <?php echo esc_html($logo_line_1); ?>
-        </span>
+        </h1>
     </div>
 
     <?php if ($logo_has_link === 'yes'): ?>


### PR DESCRIPTION
Update to the Hale Dashboard, core changes include dark mode, improved mobile desktop layout, new metrics and autocomplete search of sites.

Change log
 - Dark mode with OS detection, localStorage toggle, and FOUC-prevention inline script
  - Full govuk-frontend dark palette (header, footer, tags, banners) using CSS custom properties
  - Two-column layout: sticky metrics panel left, site list right, mobile responsive
  - Site cards redesigned with CSS Grid — domain, status, user count, environment pill buttons
  - Live search filtering by name, ID, and slug with accessible results count
  - Platform metrics: network user count and active session count added
  - Per-site "N online" badge derived from a single batch DB query
  - Grafana Nginx Ingress monitoring link added
  - Site list output cached in a 5-minute WordPress transient
  - count_users() replaced with direct COUNT query; is_plugin_active_on_site() loop replaced with get_blog_option()
  - Child theme partials/logo.php added to fix header logo not rendering on frontend
  - esc_html(), esc_url(), esc_attr() and $wpdb->prepare() applied throughout